### PR TITLE
Implement persistent cart workflow and pickup checkout

### DIFF
--- a/app/menu/[category]/CategoryMenuClient.tsx
+++ b/app/menu/[category]/CategoryMenuClient.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { InteractiveMenuCard } from "@/components/interactive-menu-card"
+import { MainNav } from "@/components/main-nav"
+import { MobileNav } from "@/components/mobile-nav"
+import { Footer } from "@/components/footer"
+import { useLanguage } from "@/contexts/language-context"
+import {
+  getLocalizedMenuSections,
+  getMenuCategoryLabelKey,
+  type MenuCategory,
+} from "@/lib/menu-data"
+
+interface CategoryMenuClientProps {
+  category: MenuCategory
+}
+
+export function CategoryMenuClient({ category }: CategoryMenuClientProps) {
+  const { t } = useLanguage()
+
+  const menuSections = useMemo(() => getLocalizedMenuSections(t), [t])
+  const items = menuSections[category] ?? []
+  const categoryLabel = t(getMenuCategoryLabelKey(category))
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="sticky top-0 z-50 w-full border-b bg-background">
+        <div className="container flex h-16 items-center justify-between">
+          <div className="hidden md:flex">
+            <MainNav />
+          </div>
+          <div className="md:hidden">
+            <MobileNav />
+          </div>
+        </div>
+      </header>
+      <main className="flex-1">
+        <div className="container py-8">
+          <h1 className="text-4xl font-bold mb-8 capitalize">{categoryLabel}</h1>
+
+          <div className="flex gap-4 mb-8">
+            <select className="px-4 py-2 border rounded-lg">
+              <option value="">Sort by</option>
+              <option value="price-low">Price: Low to High</option>
+              <option value="price-high">Price: High to Low</option>
+              <option value="rating">Rating</option>
+              <option value="popular">Popularity</option>
+            </select>
+
+            <select className="px-4 py-2 border rounded-lg">
+              <option value="">All Items</option>
+              <option value="vegetarian">Vegetarian</option>
+              <option value="spicy">Spicy</option>
+              <option value="new">New Items</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {items.map((item) => (
+              <InteractiveMenuCard key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/app/menu/[category]/page.tsx
+++ b/app/menu/[category]/page.tsx
@@ -1,123 +1,48 @@
 import { notFound } from "next/navigation"
-import { InteractiveMenuCard } from "@/components/interactive-menu-card"
-import { MainNav } from "@/components/main-nav"
-import { MobileNav } from "@/components/mobile-nav"
-import { Footer } from "@/components/footer"
-import { LanguageProvider } from "@/contexts/language-context"
 
-// Next.js 15: params is now a Promise
+import { AppProviders } from "@/contexts/app-providers"
+import { menuCatalog, type MenuCategory } from "@/lib/menu-data"
+
+import { CategoryMenuClient } from "./CategoryMenuClient"
+
 type Props = {
   params: Promise<{ category: string }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
-const validCategories = ["pizzas", "kebabs", "wraps", "sides", "drinks", "desserts"]
-
-const categoryItems = {
-  pizzas: [
-    {
-      id: 101,
-      name: "Spicy Kebab Pizza",
-      description: "Our signature pizza topped with juicy kebab meat, jalapeños, and special spicy sauce",
-      price: 14.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Specialty Pizzas",
-      rating: 4.8,
-      popular: true,
-    },
-    // Add more items...
-  ],
-  kebabs: [
-    {
-      id: 201,
-      name: "Mixed Grill Kebab",
-      description: "A delicious mix of chicken, beef, and lamb kebab with grilled vegetables",
-      price: 16.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Kebabs",
-      rating: 4.7,
-    },
-    // Add more items...
-  ],
-  // Add other categories...
-}
+const validCategories = Object.keys(menuCatalog) as MenuCategory[]
 
 export default async function CategoryPage(props: Props) {
-  // Next.js 15: Await the params
   const params = await props.params
-  const searchParams = await props.searchParams
+  await props.searchParams
 
-  const { category } = params
-  const { sort, filter } = searchParams
+  const categoryParam = params.category as MenuCategory
 
-  if (!validCategories.includes(category)) {
+  if (!validCategories.includes(categoryParam)) {
     notFound()
   }
 
-  const items = categoryItems[category as keyof typeof categoryItems] || []
-
   return (
-    <LanguageProvider>
-      <div className="flex min-h-screen flex-col">
-        <header className="sticky top-0 z-50 w-full border-b bg-background">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="hidden md:flex">
-              <MainNav />
-            </div>
-            <div className="md:hidden">
-              <MobileNav />
-            </div>
-          </div>
-        </header>
-        <main className="flex-1">
-          <div className="container py-8">
-            <h1 className="text-4xl font-bold mb-8 capitalize">{category}</h1>
-
-            {/* Filter and sort options */}
-            <div className="flex gap-4 mb-8">
-              <select className="px-4 py-2 border rounded-lg">
-                <option value="">Sort by</option>
-                <option value="price-low">Price: Low to High</option>
-                <option value="price-high">Price: High to Low</option>
-                <option value="rating">Rating</option>
-                <option value="popular">Popularity</option>
-              </select>
-
-              <select className="px-4 py-2 border rounded-lg">
-                <option value="">All Items</option>
-                <option value="vegetarian">Vegetarian</option>
-                <option value="spicy">Spicy</option>
-                <option value="new">New Items</option>
-              </select>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {items.map((item) => (
-                <InteractiveMenuCard key={item.id} item={item} />
-              ))}
-            </div>
-          </div>
-        </main>
-        <Footer />
-      </div>
-    </LanguageProvider>
+    <AppProviders>
+      <CategoryMenuClient category={categoryParam} />
+    </AppProviders>
   )
 }
 
-// Next.js 15: generateStaticParams for static generation
 export async function generateStaticParams() {
   return validCategories.map((category) => ({
     category,
   }))
 }
 
-// Next.js 15: generateMetadata with async params
 export async function generateMetadata(props: Props) {
   const params = await props.params
   const { category } = params
 
+  const capitalizedCategory = category.charAt(0).toUpperCase() + category.slice(1)
+
   return {
-    title: `${category.charAt(0).toUpperCase() + category.slice(1)} - PizzaKebab`,
+    title: `${capitalizedCategory} - PizzaKebab`,
     description: `Explore our delicious ${category} menu at PizzaKebab.`,
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link"
-import { ShoppingCart } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { MainNav } from "@/components/main-nav"
@@ -9,14 +8,15 @@ import { FeaturedItems } from "@/components/featured-items"
 import { CategorySection } from "@/components/category-section"
 import { PromoBanner } from "@/components/promo-banner"
 import { Footer } from "@/components/footer"
-import { LanguageProvider } from "@/contexts/language-context"
+import { AppProviders } from "@/contexts/app-providers"
 import { AnimatedBackground } from "@/components/animated-background"
 import { FloatingActionButton } from "@/components/floating-action-button"
 import { EnhancedTestimonials } from "@/components/enhanced-testimonials"
+import { CartStatusButton } from "@/components/cart-status-button"
 
 export default function Home() {
   return (
-    <LanguageProvider>
+    <AppProviders>
       <div className="flex min-h-screen flex-col">
         <header className="sticky top-0 z-50 w-full border-b bg-white/80 backdrop-blur-md">
           <div className="container flex h-16 items-center justify-between">
@@ -27,14 +27,7 @@ export default function Home() {
               <MobileNav />
             </div>
             <div className="flex items-center gap-4">
-              <Link href="/cart">
-                <Button variant="outline" size="icon" className="relative rounded-full">
-                  <ShoppingCart className="h-5 w-5" />
-                  <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-600 text-xs text-white">
-                    3
-                  </span>
-                </Button>
-              </Link>
+              <CartStatusButton />
               <Link href="/login">
                 <Button variant="outline" className="hidden md:inline-flex rounded-full">
                   Sign In
@@ -57,7 +50,7 @@ export default function Home() {
         <FloatingActionButton />
         <Footer />
       </div>
-    </LanguageProvider>
+    </AppProviders>
   )
 }
 

--- a/src/app/cart/CartClientPage.tsx
+++ b/src/app/cart/CartClientPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { Minus, Plus, Trash2 } from "lucide-react"
@@ -12,50 +12,45 @@ import { Input } from "@/components/ui/input"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
-import { LanguageProvider, useLanguage } from "@/contexts/language-context"
+import { useLanguage } from "@/contexts/language-context"
+import { AppProviders } from "@/contexts/app-providers"
+import { useCart } from "@/contexts/cart-context"
+import {
+  formatCurrency,
+  getLocalizedMenuItemById,
+  type LocalizedMenuItem,
+} from "@/lib/menu-data"
 
-// Sample cart data
-const initialCartItems = [
-  {
-    id: 101,
-    name: "Spicy Kebab Pizza",
-    price: 14.99,
-    quantity: 1,
-    image: "/placeholder.svg?height=100&width=100",
-  },
-  {
-    id: 201,
-    name: "Mixed Grill Kebab",
-    price: 16.99,
-    quantity: 1,
-    image: "/placeholder.svg?height=100&width=100",
-  },
-  {
-    id: 401,
-    name: "Garlic Cheese Bread",
-    price: 5.99,
-    quantity: 1,
-    image: "/placeholder.svg?height=100&width=100",
-  },
-]
+interface ResolvedCartItem {
+  id: number
+  quantity: number
+  item: LocalizedMenuItem
+}
 
 function CartContent() {
-  const [cartItems, setCartItems] = useState(initialCartItems)
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const { items, updateItemQuantity, removeItem } = useCart()
 
-  const updateQuantity = (id: number, newQuantity: number) => {
-    if (newQuantity < 1) return
+  const resolvedItems = useMemo(() => {
+    return items.reduce<ResolvedCartItem[]>((accumulator, line) => {
+      const localizedItem = getLocalizedMenuItemById(line.id, t)
+      if (!localizedItem) {
+        return accumulator
+      }
+      accumulator.push({ ...line, item: localizedItem })
+      return accumulator
+    }, [])
+  }, [items, t])
 
-    setCartItems(cartItems.map((item) => (item.id === id ? { ...item, quantity: newQuantity } : item)))
-  }
-
-  const removeItem = (id: number) => {
-    setCartItems(cartItems.filter((item) => item.id !== id))
-  }
-
-  const subtotal = cartItems.reduce((sum, item) => sum + item.price * item.quantity, 0)
-  const deliveryFee = 2.99
+  const subtotal = resolvedItems.reduce(
+    (sum, line) => sum + line.item.price * line.quantity,
+    0,
+  )
+  const deliveryFee = resolvedItems.length > 0 ? 2.99 : 0
   const total = subtotal + deliveryFee
+
+  const formatPrice = (value: number) => formatCurrency(value, language)
+  const isCartEmpty = resolvedItems.length === 0
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -73,7 +68,7 @@ function CartContent() {
         <div className="container py-8">
           <h1 className="text-3xl font-bold mb-8">{t("cart.title")}</h1>
 
-          {cartItems.length === 0 ? (
+          {isCartEmpty ? (
             <div className="text-center py-12">
               <h2 className="text-2xl font-semibold mb-4">{t("cart.empty")}</h2>
               <p className="text-muted-foreground mb-6">{t("cart.emptySubtitle")}</p>
@@ -84,51 +79,60 @@ function CartContent() {
           ) : (
             <div className="grid md:grid-cols-3 gap-8">
               <div className="md:col-span-2 space-y-4">
-                {cartItems.map((item) => (
-                  <Card key={item.id}>
-                    <CardContent className="p-4">
-                      <div className="flex items-center gap-4">
-                        <div className="relative h-20 w-20 rounded-md overflow-hidden">
-                          <Image src={item.image || "/placeholder.svg"} alt={item.name} fill className="object-cover" />
+                {resolvedItems.map(({ id, item, quantity }) => {
+                  const lineTotal = item.price * quantity
+
+                  return (
+                    <Card key={id}>
+                      <CardContent className="p-4">
+                        <div className="flex items-center gap-4">
+                          <div className="relative h-20 w-20 rounded-md overflow-hidden">
+                            <Image
+                              src={item.image || "/placeholder.svg"}
+                              alt={item.name}
+                              fill
+                              className="object-cover"
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <h3 className="font-semibold">{item.name}</h3>
+                            <p className="text-muted-foreground">{formatPrice(item.price)}</p>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => updateItemQuantity(id, quantity - 1)}
+                            >
+                              <Minus className="h-4 w-4" />
+                            </Button>
+                            <span className="w-8 text-center">{quantity}</span>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => updateItemQuantity(id, quantity + 1)}
+                            >
+                              <Plus className="h-4 w-4" />
+                            </Button>
+                          </div>
+                          <div className="text-right min-w-[80px]">
+                            <div className="font-semibold">{formatPrice(lineTotal)}</div>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-red-500 hover:text-red-700"
+                              onClick={() => removeItem(id)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
                         </div>
-                        <div className="flex-1">
-                          <h3 className="font-semibold">{item.name}</h3>
-                          <p className="text-muted-foreground">${item.price.toFixed(2)}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() => updateQuantity(item.id, item.quantity - 1)}
-                          >
-                            <Minus className="h-4 w-4" />
-                          </Button>
-                          <span className="w-8 text-center">{item.quantity}</span>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                          >
-                            <Plus className="h-4 w-4" />
-                          </Button>
-                        </div>
-                        <div className="text-right min-w-[80px]">
-                          <div className="font-semibold">${(item.price * item.quantity).toFixed(2)}</div>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 text-red-500 hover:text-red-700"
-                            onClick={() => removeItem(item.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
+                      </CardContent>
+                    </Card>
+                  )
+                })}
               </div>
 
               <div>
@@ -138,23 +142,25 @@ function CartContent() {
                     <div className="space-y-4">
                       <div className="flex justify-between">
                         <span>{t("cart.subtotal")}</span>
-                        <span>${subtotal.toFixed(2)}</span>
+                        <span>{formatPrice(subtotal)}</span>
                       </div>
                       <div className="flex justify-between">
                         <span>{t("cart.deliveryFee")}</span>
-                        <span>${deliveryFee.toFixed(2)}</span>
+                        <span>{formatPrice(deliveryFee)}</span>
                       </div>
                       <Separator />
                       <div className="flex justify-between font-bold">
                         <span>{t("cart.total")}</span>
-                        <span>${total.toFixed(2)}</span>
+                        <span>{formatPrice(total)}</span>
                       </div>
 
                       <div className="pt-4">
                         <Input placeholder={t("cart.promoCode")} className="mb-4" />
-                        <Button className="w-full bg-red-600 hover:bg-red-700 mb-2">
-                          {t("cart.proceedToCheckout")}
-                        </Button>
+                        <Link href="/order">
+                          <Button className="w-full bg-red-600 hover:bg-red-700 mb-2">
+                            {t("cart.proceedToCheckout")}
+                          </Button>
+                        </Link>
                         <Link href="/menu">
                           <Button variant="outline" className="w-full">
                             {t("cart.continueShopping")}
@@ -176,8 +182,8 @@ function CartContent() {
 
 export default function CartPageClient() {
   return (
-    <LanguageProvider>
+    <AppProviders>
       <CartContent />
-    </LanguageProvider>
+    </AppProviders>
   )
 }

--- a/src/app/menu/MenuClientPage.tsx
+++ b/src/app/menu/MenuClientPage.tsx
@@ -1,137 +1,20 @@
 "use client"
 
+import { useMemo } from "react"
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { InteractiveMenuCard } from "@/components/interactive-menu-card"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
-import { LanguageProvider, useLanguage } from "@/contexts/language-context"
+import { useLanguage } from "@/contexts/language-context"
+import { AppProviders } from "@/contexts/app-providers"
+import { getLocalizedMenuSections } from "@/lib/menu-data"
 
 function MenuContent() {
   const { t } = useLanguage()
 
-  // Update menu items with translations
-  const menuItems = {
-    pizzas: [
-      {
-        id: 101,
-        name: t("food.spicyKebabPizza.name"),
-        description: t("food.spicyKebabPizza.description"),
-        price: 14.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("common.specialtyPizzas"),
-        rating: 4.8,
-        popular: true,
-      },
-      {
-        id: 102,
-        name: t("food.margherita.name"),
-        description: t("food.margherita.description"),
-        price: 11.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("common.classicPizzas"),
-        rating: 4.6,
-      },
-      {
-        id: 103,
-        name: t("food.meatFeastPizza.name"),
-        description: t("food.meatFeastPizza.description"),
-        price: 15.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("common.specialtyPizzas"),
-        discount: 10,
-        rating: 4.9,
-      },
-      {
-        id: 104,
-        name: t("food.veggieSupreme.name"),
-        description: t("food.veggieSupreme.description"),
-        price: 13.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("common.vegetarian"),
-        rating: 4.4,
-      },
-    ],
-    kebabs: [
-      {
-        id: 201,
-        name: t("food.mixedGrillKebab.name"),
-        description: t("food.mixedGrillKebab.description"),
-        price: 16.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.kebabs"),
-        rating: 4.7,
-      },
-      {
-        id: 202,
-        name: t("food.chickenShish.name"),
-        description: t("food.chickenShish.description"),
-        price: 13.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.kebabs"),
-        rating: 4.5,
-      },
-      {
-        id: 203,
-        name: t("food.lambKofte.name"),
-        description: t("food.lambKofte.description"),
-        price: 14.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.kebabs"),
-        discount: 15,
-        rating: 4.8,
-      },
-      {
-        id: 204,
-        name: t("food.vegetableKebab.name"),
-        description: t("food.vegetableKebab.description"),
-        price: 12.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("common.vegetarian"),
-        rating: 4.3,
-      },
-    ],
-    wraps: [
-      {
-        id: 301,
-        name: t("food.chickenShawarmaWrap.name"),
-        description: t("food.chickenShawarmaWrap.description"),
-        price: 9.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.wraps"),
-        rating: 4.6,
-      },
-      {
-        id: 302,
-        name: t("food.lambDonerWrap.name"),
-        description: t("food.lambDonerWrap.description"),
-        price: 10.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.wraps"),
-        rating: 4.4,
-      },
-    ],
-    sides: [
-      {
-        id: 401,
-        name: t("food.garlicCheeseBread.name"),
-        description: t("food.garlicCheeseBread.description"),
-        price: 5.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.sides"),
-        rating: 4.5,
-      },
-      {
-        id: 402,
-        name: t("food.spicyPotatoWedges.name"),
-        description: t("food.spicyPotatoWedges.description"),
-        price: 4.99,
-        image: "/placeholder.svg?height=300&width=300",
-        category: t("categories.sides"),
-        rating: 4.2,
-      },
-    ],
-  }
+  const menuItems = useMemo(() => getLocalizedMenuSections(t), [t])
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -206,8 +89,8 @@ function MenuContent() {
 
 export default function MenuPageClient() {
   return (
-    <LanguageProvider>
+    <AppProviders>
       <MenuContent />
-    </LanguageProvider>
+    </AppProviders>
   )
 }

--- a/src/app/order/OrderClientPage.tsx
+++ b/src/app/order/OrderClientPage.tsx
@@ -2,7 +2,9 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import Link from "next/link"
+import { useMemo, useState } from "react"
+
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -11,347 +13,505 @@ import { Separator } from "@/components/ui/separator"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
-import { LanguageProvider, useLanguage } from "@/contexts/language-context"
+import { useLanguage } from "@/contexts/language-context"
+import { AppProviders } from "@/contexts/app-providers"
+import { useCart } from "@/contexts/cart-context"
+import {
+  formatCurrency,
+  getLocalizedMenuItemById,
+  type LocalizedMenuItem,
+} from "@/lib/menu-data"
+import type { TranslationKey } from "@/lib/translations"
+
+type PaymentMethod = "card" | "cash"
+type FulfillmentMethod = "delivery" | "pickup"
 
 interface OrderForm {
-  firstName: string
-  lastName: string
-  email: string
-  phone: string
-  address: string
-  city: string
-  zipCode: string
-  paymentMethod: string
-  cardNumber?: string
-  expiryDate?: string
-  cvv?: string
-}
+   firstName: string
+   lastName: string
+   email: string
+   phone: string
+   address: string
+   city: string
+   zipCode: string
+   paymentMethod: PaymentMethod | ""
+   cardNumber?: string
+   expiryDate?: string
+   cvv?: string
+ }
+
+interface ResolvedSummaryLine {
+   id: number
+   quantity: number
+   item: LocalizedMenuItem
+ }
+
+type OrderField = keyof OrderForm
+
+const errorTranslationKeys: Record<OrderField, TranslationKey> = {
+   firstName: "orderPage.errors.firstName",
+   lastName: "orderPage.errors.lastName",
+   email: "orderPage.errors.email",
+   phone: "orderPage.errors.phone",
+   address: "orderPage.errors.address",
+   city: "orderPage.errors.city",
+   zipCode: "orderPage.errors.zipCode",
+   paymentMethod: "orderPage.errors.paymentMethod",
+   cardNumber: "orderPage.errors.cardNumber",
+   expiryDate: "orderPage.errors.expiryDate",
+   cvv: "orderPage.errors.cvv",
+ }
+
+const cardSpecificFields: OrderField[] = ["cardNumber", "expiryDate", "cvv"]
 
 function OrderContent() {
-  const { t } = useLanguage()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [formData, setFormData] = useState<OrderForm>({
-    firstName: "",
-    lastName: "",
-    email: "",
-    phone: "",
-    address: "",
-    city: "",
-    zipCode: "",
-    paymentMethod: "",
-    cardNumber: "",
-    expiryDate: "",
-    cvv: "",
-  })
-  const [errors, setErrors] = useState<Partial<OrderForm>>({})
+   const { t, language } = useLanguage()
+   const { items, clear } = useCart()
+   const [fulfillmentMethod, setFulfillmentMethod] = useState<FulfillmentMethod>("delivery")
+   const [isSubmitting, setIsSubmitting] = useState(false)
+   const [formData, setFormData] = useState<OrderForm>({
+     firstName: "",
+     lastName: "",
+     email: "",
+     phone: "",
+     address: "",
+     city: "",
+     zipCode: "",
+     paymentMethod: "",
+     cardNumber: "",
+     expiryDate: "",
+     cvv: "",
+   })
+   const [errors, setErrors] = useState<Partial<Record<OrderField, string>>>({})
 
-  const handleInputChange = (field: keyof OrderForm, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }))
-    // Clear error when user starts typing
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: undefined }))
-    }
-  }
+   const summaryItems = useMemo(() => {
+     return items.reduce<ResolvedSummaryLine[]>((accumulator, line) => {
+       const localizedItem = getLocalizedMenuItemById(line.id, t)
+       if (!localizedItem) {
+         return accumulator
+       }
+       accumulator.push({ ...line, item: localizedItem })
+       return accumulator
+     }, [])
+   }, [items, t])
 
-  const validateForm = (): boolean => {
-    const newErrors: Partial<OrderForm> = {}
+   const isCartEmpty = summaryItems.length === 0
+   const isDelivery = fulfillmentMethod === "delivery"
 
-    if (!formData.firstName) newErrors.firstName = "First name is required"
-    if (!formData.lastName) newErrors.lastName = "Last name is required"
-    if (!formData.email) newErrors.email = "Email is required"
-    if (!formData.phone) newErrors.phone = "Phone number is required"
-    if (!formData.address) newErrors.address = "Address is required"
-    if (!formData.city) newErrors.city = "City is required"
-    if (!formData.zipCode) newErrors.zipCode = "ZIP code is required"
-    if (!formData.paymentMethod) newErrors.paymentMethod = "Payment method is required"
+   const formatPrice = (value: number) => formatCurrency(value, language)
 
-    if (formData.paymentMethod === "card") {
-      if (!formData.cardNumber) newErrors.cardNumber = "Card number is required"
-      if (!formData.expiryDate) newErrors.expiryDate = "Expiry date is required"
-      if (!formData.cvv) newErrors.cvv = "CVV is required"
-    }
+   const summarySubtotal = summaryItems.reduce(
+     (sum, line) => sum + line.item.price * line.quantity,
+     0,
+   )
+   const deliveryFee = isDelivery ? 2.99 : 0
+   const taxRate = 0.08
+   const tax = summarySubtotal * taxRate
+   const orderTotal = summarySubtotal + deliveryFee + tax
 
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
+   const handleInputChange = (field: OrderField, value: string) => {
+     setFormData((previous) => ({ ...previous, [field]: value }))
+     if (errors[field]) {
+       setErrors((previous) => ({ ...previous, [field]: undefined }))
+     }
+   }
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+   const isEmpty = (value: string | PaymentMethod | undefined | "") => {
+     if (value === undefined) return true
+     return String(value).trim().length === 0
+   }
 
-    if (!validateForm()) return
+   const validateForm = (): boolean => {
+     const newErrors: Partial<Record<OrderField, string>> = {}
 
-    setIsSubmitting(true)
+     const requiredFields: OrderField[] = [
+       "firstName",
+       "lastName",
+       "email",
+       "phone",
+       "paymentMethod",
+     ]
 
-    try {
-      // Simulate API call
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+     if (isDelivery) {
+       requiredFields.push("address", "city", "zipCode")
+     }
 
-      // In a real app, you would process the order here
-      console.log("Order submitted:", formData)
+     for (const field of requiredFields) {
+       if (isEmpty(formData[field])) {
+         newErrors[field] = t(errorTranslationKeys[field])
+       }
+     }
 
-      // Redirect to success page or show success message
-      alert("Order placed successfully!")
-    } catch (error) {
-      console.error("Order submission failed:", error)
-      alert("Failed to place order. Please try again.")
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
+     if (formData.paymentMethod === "card") {
+       for (const field of cardSpecificFields) {
+         if (isEmpty(formData[field])) {
+           newErrors[field] = t(errorTranslationKeys[field])
+         }
+       }
+     }
 
-  return (
-    <div className="flex min-h-screen flex-col">
-      <header className="sticky top-0 z-50 w-full border-b bg-background">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="hidden md:flex">
-            <MainNav />
-          </div>
-          <div className="md:hidden">
-            <MobileNav />
-          </div>
-        </div>
-      </header>
+     setErrors(newErrors)
+     return Object.keys(newErrors).length === 0
+   }
 
-      <main className="flex-1">
-        <div className="container py-8">
-          <h1 className="text-3xl font-bold mb-8">Complete Your Order</h1>
+   const onSubmit = async (event: React.FormEvent) => {
+     event.preventDefault()
 
-          <form onSubmit={(e) => onSubmit(e)} className="grid md:grid-cols-2 gap-8">
-            {/* Customer Information */}
-            <div className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Customer Information</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="firstName">First Name</Label>
-                      <Input
-                        id="firstName"
-                        value={formData.firstName}
-                        onChange={(e) => handleInputChange("firstName", e.target.value)}
-                        className={errors.firstName ? "border-red-500" : ""}
-                      />
-                      {errors.firstName && <p className="text-red-500 text-sm mt-1">{errors.firstName.message}</p>}
-                    </div>
-                    <div>
-                      <Label htmlFor="lastName">Last Name</Label>
-                      <Input
-                        id="lastName"
-                        value={formData.lastName}
-                        onChange={(e) => handleInputChange("lastName", e.target.value)}
-                        className={errors.lastName ? "border-red-500" : ""}
-                      />
-                      {errors.lastName && <p className="text-red-500 text-sm mt-1">{errors.lastName.message}</p>}
-                    </div>
-                  </div>
+     if (isCartEmpty) {
+       return
+     }
 
-                  <div>
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      value={formData.email}
-                      onChange={(e) => handleInputChange("email", e.target.value)}
-                      className={errors.email ? "border-red-500" : ""}
-                    />
-                    {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}
-                  </div>
+     if (!validateForm()) {
+       return
+     }
 
-                  <div>
-                    <Label htmlFor="phone">Phone</Label>
-                    <Input
-                      id="phone"
-                      value={formData.phone}
-                      onChange={(e) => handleInputChange("phone", e.target.value)}
-                      className={errors.phone ? "border-red-500" : ""}
-                    />
-                    {errors.phone && <p className="text-red-500 text-sm mt-1">{errors.phone.message}</p>}
-                  </div>
-                </CardContent>
-              </Card>
+     setIsSubmitting(true)
 
-              {/* Delivery Address */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Delivery Address</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <Label htmlFor="address">Street Address</Label>
-                    <Input
-                      id="address"
-                      value={formData.address}
-                      onChange={(e) => handleInputChange("address", e.target.value)}
-                      className={errors.address ? "border-red-500" : ""}
-                    />
-                    {errors.address && <p className="text-red-500 text-sm mt-1">{errors.address.message}</p>}
-                  </div>
+     try {
+       await new Promise((resolve) => setTimeout(resolve, 2000))
+       console.log("Order submitted:", { formData, fulfillmentMethod, items })
+       clear()
+       setFormData({
+         firstName: "",
+         lastName: "",
+         email: "",
+         phone: "",
+         address: "",
+         city: "",
+         zipCode: "",
+         paymentMethod: "",
+         cardNumber: "",
+         expiryDate: "",
+         cvv: "",
+       })
+       setFulfillmentMethod("delivery")
+       window.alert(t("orderPage.notifications.success"))
+     } catch (error) {
+       console.error("Order submission failed:", error)
+       window.alert(t("orderPage.notifications.failure"))
+     } finally {
+       setIsSubmitting(false)
+     }
+   }
 
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="city">City</Label>
-                      <Input
-                        id="city"
-                        value={formData.city}
-                        onChange={(e) => handleInputChange("city", e.target.value)}
-                        className={errors.city ? "border-red-500" : ""}
-                      />
-                      {errors.city && <p className="text-red-500 text-sm mt-1">{errors.city.message}</p>}
-                    </div>
-                    <div>
-                      <Label htmlFor="zipCode">ZIP Code</Label>
-                      <Input
-                        id="zipCode"
-                        value={formData.zipCode}
-                        onChange={(e) => handleInputChange("zipCode", e.target.value)}
-                        className={errors.zipCode ? "border-red-500" : ""}
-                      />
-                      {errors.zipCode && <p className="text-red-500 text-sm mt-1">{errors.zipCode.message}</p>}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
+   return (
+     <div className="flex min-h-screen flex-col">
+       <header className="sticky top-0 z-50 w-full border-b bg-background">
+         <div className="container flex h-16 items-center justify-between">
+           <div className="hidden md:flex">
+             <MainNav />
+           </div>
+           <div className="md:hidden">
+             <MobileNav />
+           </div>
+         </div>
+       </header>
 
-              {/* Payment Method */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Payment Method</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-2">
-                    <label className="flex items-center space-x-2">
-                      <input
-                        type="radio"
-                        value="card"
-                        checked={formData.paymentMethod === "card"}
-                        onChange={() => handleInputChange("paymentMethod", "card")}
-                      />
-                      <span>Credit/Debit Card</span>
-                    </label>
-                    <label className="flex items-center space-x-2">
-                      <input
-                        type="radio"
-                        value="cash"
-                        checked={formData.paymentMethod === "cash"}
-                        onChange={() => handleInputChange("paymentMethod", "cash")}
-                      />
-                      <span>Cash on Delivery</span>
-                    </label>
-                  </div>
+       <main className="flex-1">
+         <div className="container py-8">
+           <h1 className="text-3xl font-bold mb-8">{t("orderPage.title")}</h1>
 
-                  {formData.paymentMethod === "card" && (
-                    <div className="space-y-4 pt-4 border-t">
-                      <div>
-                        <Label htmlFor="cardNumber">Card Number</Label>
-                        <Input
-                          id="cardNumber"
-                          placeholder="1234 5678 9012 3456"
-                          value={formData.cardNumber}
-                          onChange={(e) => handleInputChange("cardNumber", e.target.value)}
-                          className={errors.cardNumber ? "border-red-500" : ""}
-                        />
-                        {errors.cardNumber && <p className="text-red-500 text-sm mt-1">{errors.cardNumber.message}</p>}
-                      </div>
+           {isCartEmpty ? (
+             <Card className="max-w-xl mx-auto">
+               <CardHeader>
+                 <CardTitle>{t("orderPage.empty.title")}</CardTitle>
+               </CardHeader>
+               <CardContent className="space-y-4">
+                 <p className="text-muted-foreground">{t("orderPage.empty.subtitle")}</p>
+                 <Button asChild className="bg-red-600 hover:bg-red-700">
+                   <Link href="/menu">{t("orderPage.empty.cta")}</Link>
+                 </Button>
+               </CardContent>
+             </Card>
+           ) : (
+             <form onSubmit={onSubmit} className="grid md:grid-cols-2 gap-8">
+               <div className="space-y-6">
+                 <Card>
+                   <CardHeader>
+                     <CardTitle>{t("orderPage.sections.fulfillment")}</CardTitle>
+                   </CardHeader>
+                   <CardContent className="space-y-4">
+                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                       <Button
+                         type="button"
+                         variant={isDelivery ? "default" : "outline"}
+                         className="h-auto py-4 flex-col items-start text-left"
+                         onClick={() => setFulfillmentMethod("delivery")}
+                       >
+                         <span className="font-semibold">{t("orderPage.fulfillment.delivery")}</span>
+                         <span className="text-sm text-muted-foreground">
+                           {t("orderPage.fulfillment.deliveryDescription")}
+                         </span>
+                       </Button>
+                       <Button
+                         type="button"
+                         variant={!isDelivery ? "default" : "outline"}
+                         className="h-auto py-4 flex-col items-start text-left"
+                         onClick={() => setFulfillmentMethod("pickup")}
+                       >
+                         <span className="font-semibold">{t("orderPage.fulfillment.pickup")}</span>
+                         <span className="text-sm text-muted-foreground">
+                           {t("orderPage.fulfillment.pickupDescription")}
+                         </span>
+                       </Button>
+                     </div>
+                   </CardContent>
+                 </Card>
 
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <Label htmlFor="expiryDate">Expiry Date</Label>
-                          <Input
-                            id="expiryDate"
-                            placeholder="MM/YY"
-                            value={formData.expiryDate}
-                            onChange={(e) => handleInputChange("expiryDate", e.target.value)}
-                            className={errors.expiryDate ? "border-red-500" : ""}
-                          />
-                          {errors.expiryDate && (
-                            <p className="text-red-500 text-sm mt-1">{errors.expiryDate.message}</p>
-                          )}
-                        </div>
-                        <div>
-                          <Label htmlFor="cvv">CVV</Label>
-                          <Input
-                            id="cvv"
-                            placeholder="123"
-                            value={formData.cvv}
-                            onChange={(e) => handleInputChange("cvv", e.target.value)}
-                            className={errors.cvv ? "border-red-500" : ""}
-                          />
-                          {errors.cvv && <p className="text-red-500 text-sm mt-1">{errors.cvv.message}</p>}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
+                 <Card>
+                   <CardHeader>
+                     <CardTitle>{t("orderPage.sections.customerInformation")}</CardTitle>
+                   </CardHeader>
+                   <CardContent className="space-y-4">
+                     <div className="grid grid-cols-2 gap-4">
+                       <div>
+                         <Label htmlFor="firstName">{t("orderPage.fields.firstName")}</Label>
+                         <Input
+                           id="firstName"
+                           value={formData.firstName}
+                           onChange={(event) => handleInputChange("firstName", event.target.value)}
+                           className={errors.firstName ? "border-red-500" : ""}
+                         />
+                         {errors.firstName && <p className="text-red-500 text-sm mt-1">{errors.firstName}</p>}
+                       </div>
+                       <div>
+                         <Label htmlFor="lastName">{t("orderPage.fields.lastName")}</Label>
+                         <Input
+                           id="lastName"
+                           value={formData.lastName}
+                           onChange={(event) => handleInputChange("lastName", event.target.value)}
+                           className={errors.lastName ? "border-red-500" : ""}
+                         />
+                         {errors.lastName && <p className="text-red-500 text-sm mt-1">{errors.lastName}</p>}
+                       </div>
+                     </div>
 
-            {/* Order Summary */}
-            <div>
-              <Card className="sticky top-24">
-                <CardHeader>
-                  <CardTitle>Order Summary</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Spicy Kebab Pizza</span>
-                      <span>$14.99</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Mixed Grill Kebab</span>
-                      <span>$16.99</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Garlic Cheese Bread</span>
-                      <span>$5.99</span>
-                    </div>
-                  </div>
+                     <div>
+                       <Label htmlFor="email">{t("orderPage.fields.email")}</Label>
+                       <Input
+                         id="email"
+                         type="email"
+                         value={formData.email}
+                         onChange={(event) => handleInputChange("email", event.target.value)}
+                         className={errors.email ? "border-red-500" : ""}
+                       />
+                       {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+                     </div>
 
-                  <Separator />
+                     <div>
+                       <Label htmlFor="phone">{t("orderPage.fields.phone")}</Label>
+                       <Input
+                         id="phone"
+                         value={formData.phone}
+                         onChange={(event) => handleInputChange("phone", event.target.value)}
+                         className={errors.phone ? "border-red-500" : ""}
+                       />
+                       {errors.phone && <p className="text-red-500 text-sm mt-1">{errors.phone}</p>}
+                     </div>
+                   </CardContent>
+                 </Card>
 
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Subtotal</span>
-                      <span>$37.97</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Delivery Fee</span>
-                      <span>$2.99</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Tax</span>
-                      <span>$3.28</span>
-                    </div>
-                  </div>
+                 {isDelivery && (
+                   <Card>
+                     <CardHeader>
+                       <CardTitle>{t("orderPage.sections.deliveryAddress")}</CardTitle>
+                     </CardHeader>
+                     <CardContent className="space-y-4">
+                       <div>
+                         <Label htmlFor="address">{t("orderPage.fields.address")}</Label>
+                         <Input
+                           id="address"
+                           value={formData.address}
+                           onChange={(event) => handleInputChange("address", event.target.value)}
+                           className={errors.address ? "border-red-500" : ""}
+                         />
+                         {errors.address && <p className="text-red-500 text-sm mt-1">{errors.address}</p>}
+                       </div>
 
-                  <Separator />
+                       <div className="grid grid-cols-2 gap-4">
+                         <div>
+                           <Label htmlFor="city">{t("orderPage.fields.city")}</Label>
+                           <Input
+                             id="city"
+                             value={formData.city}
+                             onChange={(event) => handleInputChange("city", event.target.value)}
+                             className={errors.city ? "border-red-500" : ""}
+                           />
+                           {errors.city && <p className="text-red-500 text-sm mt-1">{errors.city}</p>}
+                         </div>
+                         <div>
+                           <Label htmlFor="zipCode">{t("orderPage.fields.zipCode")}</Label>
+                           <Input
+                             id="zipCode"
+                             value={formData.zipCode}
+                             onChange={(event) => handleInputChange("zipCode", event.target.value)}
+                             className={errors.zipCode ? "border-red-500" : ""}
+                           />
+                           {errors.zipCode && <p className="text-red-500 text-sm mt-1">{errors.zipCode}</p>}
+                         </div>
+                       </div>
+                     </CardContent>
+                   </Card>
+                 )}
 
-                  <div className="flex justify-between font-bold text-lg">
-                    <span>Total</span>
-                    <span>$44.24</span>
-                  </div>
+                 <Card>
+                   <CardHeader>
+                     <CardTitle>{t("orderPage.sections.paymentMethod")}</CardTitle>
+                   </CardHeader>
+                   <CardContent className="space-y-4">
+                     <div className="space-y-2">
+                       <label className="flex items-center space-x-2">
+                         <input
+                           type="radio"
+                           value="card"
+                           checked={formData.paymentMethod === "card"}
+                           onChange={() => handleInputChange("paymentMethod", "card")}
+                         />
+                         <span>{t("orderPage.paymentMethods.card")}</span>
+                       </label>
+                       <label className="flex items-center space-x-2">
+                         <input
+                           type="radio"
+                           value="cash"
+                           checked={formData.paymentMethod === "cash"}
+                           onChange={() => handleInputChange("paymentMethod", "cash")}
+                         />
+                         <span>{t("orderPage.paymentMethods.cash")}</span>
+                       </label>
+                     </div>
 
-                  <Button type="submit" className="w-full bg-red-600 hover:bg-red-700 mt-6" disabled={isSubmitting}>
-                    {isSubmitting ? "Processing..." : "Place Order"}
-                  </Button>
-                </CardContent>
-              </Card>
-            </div>
-          </form>
-        </div>
-      </main>
+                     {errors.paymentMethod && (
+                       <p className="text-red-500 text-sm">{errors.paymentMethod}</p>
+                     )}
 
-      <Footer />
-    </div>
-  )
-}
+                     {formData.paymentMethod === "card" && (
+                       <div className="space-y-4 pt-4 border-t">
+                         <div>
+                           <Label htmlFor="cardNumber">{t("orderPage.fields.cardNumber")}</Label>
+                           <Input
+                             id="cardNumber"
+                             placeholder={t("orderPage.placeholders.cardNumber")}
+                             value={formData.cardNumber}
+                             onChange={(event) => handleInputChange("cardNumber", event.target.value)}
+                             className={errors.cardNumber ? "border-red-500" : ""}
+                           />
+                           {errors.cardNumber && (
+                             <p className="text-red-500 text-sm mt-1">{errors.cardNumber}</p>
+                           )}
+                         </div>
 
-export default function OrderClientPage() {
-  return (
-    <LanguageProvider>
-      <OrderContent />
-    </LanguageProvider>
-  )
-}
+                         <div className="grid grid-cols-2 gap-4">
+                           <div>
+                             <Label htmlFor="expiryDate">{t("orderPage.fields.expiryDate")}</Label>
+                             <Input
+                               id="expiryDate"
+                               placeholder={t("orderPage.placeholders.expiryDate")}
+                               value={formData.expiryDate}
+                               onChange={(event) => handleInputChange("expiryDate", event.target.value)}
+                               className={errors.expiryDate ? "border-red-500" : ""}
+                             />
+                             {errors.expiryDate && (
+                               <p className="text-red-500 text-sm mt-1">{errors.expiryDate}</p>
+                             )}
+                           </div>
+                           <div>
+                             <Label htmlFor="cvv">{t("orderPage.fields.cvv")}</Label>
+                             <Input
+                               id="cvv"
+                               placeholder={t("orderPage.placeholders.cvv")}
+                               value={formData.cvv}
+                               onChange={(event) => handleInputChange("cvv", event.target.value)}
+                               className={errors.cvv ? "border-red-500" : ""}
+                             />
+                             {errors.cvv && <p className="text-red-500 text-sm mt-1">{errors.cvv}</p>}
+                           </div>
+                         </div>
+                       </div>
+                     )}
+                   </CardContent>
+                 </Card>
+               </div>
+
+               <div>
+                 <Card className="sticky top-24">
+                   <CardHeader>
+                     <CardTitle>{t("orderPage.sections.summary")}</CardTitle>
+                   </CardHeader>
+                   <CardContent className="space-y-4">
+                     <div className="space-y-2">
+                       {summaryItems.map(({ id, item, quantity }) => {
+                         const lineTotal = item.price * quantity
+                         return (
+                           <div className="flex justify-between" key={id}>
+                             <span>
+                               {item.name} × {quantity}
+                             </span>
+                             <span>{formatPrice(lineTotal)}</span>
+                           </div>
+                         )
+                       })}
+                     </div>
+
+                     <Separator />
+
+                     <div className="space-y-2 text-sm text-muted-foreground">
+                       <div className="flex justify-between">
+                         <span>{t("orderPage.summary.fulfillment")}</span>
+                         <span>
+                           {t(
+                             fulfillmentMethod === "delivery"
+                               ? "orderPage.fulfillment.delivery"
+                               : "orderPage.fulfillment.pickup",
+                           )}
+                         </span>
+                       </div>
+                       <div className="flex justify-between">
+                         <span>{t("orderPage.summary.subtotal")}</span>
+                         <span>{formatPrice(summarySubtotal)}</span>
+                       </div>
+                       <div className="flex justify-between">
+                         <span>{t("orderPage.summary.deliveryFee")}</span>
+                         <span>{formatPrice(deliveryFee)}</span>
+                       </div>
+                       <div className="flex justify-between">
+                         <span>{t("orderPage.summary.tax")}</span>
+                         <span>{formatPrice(tax)}</span>
+                       </div>
+                     </div>
+
+                     <Separator />
+
+                     <div className="flex justify-between font-bold text-lg">
+                       <span>{t("orderPage.summary.total")}</span>
+                       <span>{formatPrice(orderTotal)}</span>
+                     </div>
+
+                     <Button
+                       type="submit"
+                       className="w-full bg-red-600 hover:bg-red-700 mt-6"
+                       disabled={isSubmitting}
+                     >
+                       {isSubmitting
+                         ? t("orderPage.actions.processing")
+                         : t("orderPage.actions.placeOrder")}
+                     </Button>
+                   </CardContent>
+                 </Card>
+               </div>
+             </form>
+           )}
+         </div>
+       </main>
+
+       <Footer />
+     </div>
+   )
+ }
+
+ export default function OrderClientPage() {
+   return (
+     <AppProviders>
+       <OrderContent />
+     </AppProviders>
+   )
+ }

--- a/src/components/cart-status-button.tsx
+++ b/src/components/cart-status-button.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import Link from "next/link"
+import { ShoppingCart } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { useCart } from "@/contexts/cart-context"
+import { useLanguage } from "@/contexts/language-context"
+import { cn } from "@/lib/utils"
+
+interface CartStatusButtonProps {
+  className?: string
+}
+
+export function CartStatusButton({ className }: CartStatusButtonProps) {
+  const { totalItems } = useCart()
+  const { t } = useLanguage()
+
+  return (
+    <Button
+      asChild
+      variant="outline"
+      size="icon"
+      className={cn("relative rounded-full", className)}
+    >
+      <Link href="/cart" aria-label={t("nav.cart")}
+        className="flex h-full w-full items-center justify-center"
+      >
+        <ShoppingCart className="h-5 w-5" />
+        {totalItems > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-600 text-xs font-semibold text-white">
+            {totalItems}
+          </span>
+        )}
+      </Link>
+    </Button>
+  )
+}

--- a/src/components/category-section.tsx
+++ b/src/components/category-section.tsx
@@ -6,53 +6,43 @@ import { ArrowRight, Flame } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
+import {
+  getMenuCategoryCount,
+  getMenuCategoryLabelKey,
+  type MenuCategory,
+} from "@/lib/menu-data"
 
 export function CategorySection() {
   const { t } = useLanguage()
 
+  const coreCategories: Array<{ key: MenuCategory; featured?: boolean }> = [
+    { key: "pizzas", featured: true },
+    { key: "kebabs", featured: true },
+    { key: "wraps" },
+    { key: "sides" },
+  ]
+
   const categories = [
-    {
-      id: 1,
-      name: t("categories.pizzas"),
+    ...coreCategories.map(({ key, featured }) => ({
+      id: key,
+      name: t(getMenuCategoryLabelKey(key)),
       image: "/placeholder.svg?height=400&width=400",
-      count: 12,
-      href: "/menu/pizzas",
-      featured: true,
-    },
+      count: getMenuCategoryCount(key),
+      href: `/menu/${key}`,
+      featured,
+    })),
     {
-      id: 2,
-      name: t("categories.kebabs"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 8,
-      href: "/menu/kebabs",
-      featured: true,
-    },
-    {
-      id: 3,
-      name: t("categories.wraps"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 6,
-      href: "/menu/wraps",
-    },
-    {
-      id: 4,
-      name: t("categories.sides"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 10,
-      href: "/menu/sides",
-    },
-    {
-      id: 5,
+      id: "drinks",
       name: t("categories.drinks"),
       image: "/placeholder.svg?height=400&width=400",
-      count: 15,
+      count: 6,
       href: "/menu/drinks",
     },
     {
-      id: 6,
+      id: "desserts",
       name: t("categories.desserts"),
       image: "/placeholder.svg?height=400&width=400",
-      count: 7,
+      count: 4,
       href: "/menu/desserts",
     },
   ]

--- a/src/components/featured-items.tsx
+++ b/src/components/featured-items.tsx
@@ -1,76 +1,18 @@
 "use client"
 
-import { useState, useRef, useEffect } from "react"
+import { useState, useRef, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { ChevronLeft, ChevronRight, Utensils } from "lucide-react"
 
 import { InteractiveMenuCard } from "@/components/interactive-menu-card"
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
+import { getFeaturedMenuItems } from "@/lib/menu-data"
 
 export function FeaturedItems() {
   const { t } = useLanguage()
 
-  const featuredItems = [
-    {
-      id: 1,
-      name: t("food.spicyKebabPizza.name"),
-      description: t("food.spicyKebabPizza.description"),
-      price: 14.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("common.specialtyPizzas"),
-      rating: 4.8,
-      popular: true,
-    },
-    {
-      id: 2,
-      name: t("food.mixedGrillKebab.name"),
-      description: t("food.mixedGrillKebab.description"),
-      price: 16.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("categories.kebabs"),
-      rating: 4.7,
-    },
-    {
-      id: 3,
-      name: t("food.garlicCheeseBread.name"),
-      description: t("food.garlicCheeseBread.description"),
-      price: 5.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("categories.sides"),
-      rating: 4.5,
-    },
-    {
-      id: 4,
-      name: t("food.chickenShawarmaWrap.name"),
-      description: t("food.chickenShawarmaWrap.description"),
-      price: 9.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("categories.wraps"),
-      rating: 4.6,
-    },
-    {
-      id: 5,
-      name: t("food.meatFeastPizza.name"),
-      description: t("food.meatFeastPizza.description"),
-      price: 15.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("common.specialtyPizzas"),
-      rating: 4.9,
-      popular: true,
-      discount: 10,
-    },
-    {
-      id: 6,
-      name: t("food.falafelWrap.name"),
-      description: t("food.falafelWrap.description"),
-      price: 8.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: t("common.vegetarian"),
-      rating: 4.4,
-      new: true,
-    },
-  ]
+  const featuredItems = useMemo(() => getFeaturedMenuItems(t), [t])
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)

--- a/src/components/food-card.tsx
+++ b/src/components/food-card.tsx
@@ -9,6 +9,8 @@ import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { useLanguage } from "@/contexts/language-context"
+import { useCart } from "@/contexts/cart-context"
+import { formatCurrency } from "@/lib/menu-data"
 
 interface FoodItem {
   id: number
@@ -30,16 +32,21 @@ interface FoodCardProps {
 export function FoodCard({ item }: FoodCardProps) {
   const [isHovered, setIsHovered] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
+  const { addItem } = useCart()
 
-  const displayPrice = item.discount
-    ? (item.price - (item.price * item.discount) / 100).toFixed(2)
-    : item.price.toFixed(2)
+  const discountedPrice = item.discount
+    ? item.price - (item.price * item.discount) / 100
+    : item.price
+  const formattedPrice = formatCurrency(discountedPrice, language)
+  const formattedOriginalPrice = item.discount
+    ? formatCurrency(item.price, language)
+    : undefined
 
   const handleAddToCart = () => {
+    addItem(item.id, 1)
     setIsAdding(true)
     setTimeout(() => setIsAdding(false), 1000)
-    // Add to cart logic would go here
   }
 
   return (
@@ -94,9 +101,9 @@ export function FoodCard({ item }: FoodCardProps) {
       </CardContent>
       <CardFooter className="flex justify-between items-center pt-0 pb-4">
         <div className="font-bold text-lg">
-          <span className="text-red-600">${displayPrice}</span>
-          {item.discount && (
-            <span className="text-sm text-muted-foreground line-through ml-2">${item.price.toFixed(2)}</span>
+          <span className="text-red-600">{formattedPrice}</span>
+          {formattedOriginalPrice && (
+            <span className="text-sm text-muted-foreground line-through ml-2">{formattedOriginalPrice}</span>
           )}
         </div>
         <div className="flex gap-2">

--- a/src/contexts/app-providers.tsx
+++ b/src/contexts/app-providers.tsx
@@ -1,0 +1,14 @@
+"use client"
+
+import type { ReactNode } from "react"
+
+import { CartProvider } from "./cart-context"
+import { LanguageProvider } from "./language-context"
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  return (
+    <LanguageProvider>
+      <CartProvider>{children}</CartProvider>
+    </LanguageProvider>
+  )
+}

--- a/src/contexts/cart-context.tsx
+++ b/src/contexts/cart-context.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+
+export interface CartItem {
+  id: number
+  quantity: number
+}
+
+interface CartContextValue {
+  items: CartItem[]
+  addItem: (id: number, quantity?: number) => void
+  updateItemQuantity: (id: number, quantity: number) => void
+  removeItem: (id: number) => void
+  clear: () => void
+  getItemQuantity: (id: number) => number
+  totalItems: number
+}
+
+const CartContext = createContext<CartContextValue | undefined>(undefined)
+
+const STORAGE_KEY = "pizzakebab-cart-items"
+
+type CartDraft = Record<number, CartItem>
+
+const toDraft = (items: CartItem[]): CartDraft => {
+  return items.reduce<CartDraft>((draft, line) => {
+    draft[line.id] = line
+    return draft
+  }, {})
+}
+
+const fromDraft = (draft: CartDraft | undefined | null): CartItem[] => {
+  if (!draft) return []
+  return Object.values(draft)
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>([])
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as CartDraft
+      setItems(fromDraft(parsed))
+    } catch (error) {
+      console.warn("Unable to read cart from storage", error)
+    }
+  }, [])
+
+  useEffect(() => {
+    try {
+      const draft = toDraft(items)
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(draft))
+    } catch (error) {
+      console.warn("Unable to persist cart", error)
+    }
+  }, [items])
+
+  const addItem = useCallback((id: number, quantity = 1) => {
+    setItems((previous) => {
+      const draft = toDraft(previous)
+      const existing = draft[id]
+      const nextQuantity = Math.max(1, (existing?.quantity ?? 0) + quantity)
+      draft[id] = { id, quantity: nextQuantity }
+      return fromDraft(draft)
+    })
+  }, [])
+
+  const updateItemQuantity = useCallback((id: number, quantity: number) => {
+    if (quantity < 1) {
+      setItems((previous) => previous.filter((line) => line.id !== id))
+      return
+    }
+    setItems((previous) => {
+      const draft = toDraft(previous)
+      if (!draft[id]) return previous
+      draft[id] = { id, quantity }
+      return fromDraft(draft)
+    })
+  }, [])
+
+  const removeItem = useCallback((id: number) => {
+    setItems((previous) => previous.filter((line) => line.id !== id))
+  }, [])
+
+  const clear = useCallback(() => {
+    setItems([])
+  }, [])
+
+  const getItemQuantity = useCallback(
+    (id: number) => {
+      const match = items.find((line) => line.id === id)
+      return match?.quantity ?? 0
+    },
+    [items],
+  )
+
+  const totalItems = useMemo(() => items.reduce((sum, line) => sum + line.quantity, 0), [items])
+
+  const value = useMemo(
+    () => ({ items, addItem, updateItemQuantity, removeItem, clear, getItemQuantity, totalItems }),
+    [items, addItem, updateItemQuantity, removeItem, clear, getItemQuantity, totalItems],
+  )
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>
+}
+
+export function useCart() {
+  const context = useContext(CartContext)
+  if (!context) {
+    throw new Error("useCart must be used within a CartProvider")
+  }
+  return context
+}

--- a/src/lib/menu-data.ts
+++ b/src/lib/menu-data.ts
@@ -1,0 +1,245 @@
+import type { TranslationKey, FoodKey, Language } from "@/lib/translations"
+
+export type MenuCategory = "pizzas" | "kebabs" | "wraps" | "sides"
+
+type CategoryTranslationKey = Extract<
+  TranslationKey,
+  `categories.${string}` | `common.${string}`
+>
+
+interface MenuItemDefinition<TFood extends FoodKey = FoodKey> {
+  id: number
+  food: TFood
+  price: number
+  image: string
+  categoryKey: CategoryTranslationKey
+  rating?: number
+  popular?: boolean
+  discount?: number
+  new?: boolean
+}
+
+export interface LocalizedMenuItem {
+  id: number
+  name: string
+  description: string
+  price: number
+  image: string
+  category: string
+  rating?: number
+  popular?: boolean
+  discount?: number
+  new?: boolean
+}
+
+const BASE_IMAGE = "/placeholder.svg?height=300&width=300"
+
+export const menuCatalog: Record<MenuCategory, readonly MenuItemDefinition[]> = {
+  pizzas: [
+    {
+      id: 101,
+      food: "spicyKebabPizza",
+      price: 14.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.specialtyPizzas",
+      rating: 4.8,
+      popular: true,
+    },
+    {
+      id: 102,
+      food: "margherita",
+      price: 11.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.classicPizzas",
+      rating: 4.6,
+    },
+    {
+      id: 103,
+      food: "meatFeastPizza",
+      price: 15.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.specialtyPizzas",
+      discount: 10,
+      rating: 4.9,
+    },
+    {
+      id: 104,
+      food: "veggieSupreme",
+      price: 13.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.vegetarian",
+      rating: 4.4,
+    },
+  ],
+  kebabs: [
+    {
+      id: 201,
+      food: "mixedGrillKebab",
+      price: 16.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.kebabs",
+      rating: 4.7,
+    },
+    {
+      id: 202,
+      food: "chickenShish",
+      price: 13.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.kebabs",
+      rating: 4.5,
+    },
+    {
+      id: 203,
+      food: "lambKofte",
+      price: 14.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.kebabs",
+      discount: 15,
+      rating: 4.8,
+    },
+    {
+      id: 204,
+      food: "vegetableKebab",
+      price: 12.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.vegetarian",
+      rating: 4.3,
+    },
+  ],
+  wraps: [
+    {
+      id: 301,
+      food: "chickenShawarmaWrap",
+      price: 9.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.wraps",
+      rating: 4.6,
+    },
+    {
+      id: 302,
+      food: "lambDonerWrap",
+      price: 10.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.wraps",
+      rating: 4.4,
+    },
+    {
+      id: 303,
+      food: "falafelWrap",
+      price: 8.99,
+      image: BASE_IMAGE,
+      categoryKey: "common.vegetarian",
+      rating: 4.4,
+      new: true,
+    },
+  ],
+  sides: [
+    {
+      id: 401,
+      food: "garlicCheeseBread",
+      price: 5.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.sides",
+      rating: 4.5,
+    },
+    {
+      id: 402,
+      food: "spicyPotatoWedges",
+      price: 4.99,
+      image: BASE_IMAGE,
+      categoryKey: "categories.sides",
+      rating: 4.2,
+    },
+  ],
+} as const
+
+const catalogEntries = Object.entries(menuCatalog) as [
+  MenuCategory,
+  readonly MenuItemDefinition[],
+][]
+
+const menuItemIndex = new Map<number, MenuItemDefinition>(
+  catalogEntries.flatMap(([, items]) => items.map((item) => [item.id, item] as const)),
+)
+
+const toTranslationKey = <TKey extends TranslationKey>(key: TKey) => key
+
+const resolveMenuItem = (
+  definition: MenuItemDefinition,
+  translate: (key: TranslationKey) => string,
+): LocalizedMenuItem => {
+  const nameKey = toTranslationKey(`food.${definition.food}.name` as const)
+  const descriptionKey = toTranslationKey(`food.${definition.food}.description` as const)
+
+  return {
+    id: definition.id,
+    name: translate(nameKey),
+    description: translate(descriptionKey),
+    price: definition.price,
+    image: definition.image,
+    category: translate(toTranslationKey(definition.categoryKey)),
+    rating: definition.rating,
+    popular: definition.popular,
+    discount: definition.discount,
+    new: definition.new,
+  }
+}
+
+export const getLocalizedMenuSections = (
+  translate: (key: TranslationKey) => string,
+): Record<MenuCategory, LocalizedMenuItem[]> =>
+  Object.fromEntries(
+    catalogEntries.map(([category, items]) => [
+      category,
+      items.map((item) => resolveMenuItem(item, translate)),
+    ]),
+  ) as Record<MenuCategory, LocalizedMenuItem[]>
+
+export const getLocalizedMenuItemById = (
+  id: number,
+  translate: (key: TranslationKey) => string,
+): LocalizedMenuItem | undefined => {
+  const definition = menuItemIndex.get(id)
+  return definition ? resolveMenuItem(definition, translate) : undefined
+}
+
+export const defaultFeaturedItemIds = [101, 201, 401, 301, 103, 303] as const
+
+export const getFeaturedMenuItems = (
+  translate: (key: TranslationKey) => string,
+  ids: readonly number[] = defaultFeaturedItemIds,
+): LocalizedMenuItem[] =>
+  ids
+    .map((id) => menuItemIndex.get(id))
+    .filter((definition): definition is MenuItemDefinition => Boolean(definition))
+    .map((definition) => resolveMenuItem(definition, translate))
+
+export const getMenuCategoryLabelKey = (category: MenuCategory): TranslationKey =>
+  toTranslationKey(`categories.${category}` as const)
+
+export const getMenuCategoryCount = (category: MenuCategory): number =>
+  menuCatalog[category].length
+
+const localeByLanguage: Record<Language, string> = {
+  en: "en-US",
+  fr: "fr-FR",
+  de: "de-DE",
+}
+
+const currencyByLanguage: Record<Language, string> = {
+  en: "USD",
+  fr: "EUR",
+  de: "EUR",
+}
+
+export const formatCurrency = (value: number, language: Language): string => {
+  const locale = localeByLanguage[language] ?? "en-US"
+  const currency = currencyByLanguage[language] ?? "USD"
+
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -135,6 +135,78 @@ export const translations = {
       proceedToCheckout: "Proceed to Checkout",
       continueShopping: "Continue Shopping",
     },
+    // Order Page
+    orderPage: {
+      title: "Complete Your Order",
+      sections: {
+        fulfillment: "How would you like to get your order?",
+        customerInformation: "Customer Information",
+        deliveryAddress: "Delivery Address",
+        paymentMethod: "Payment Method",
+        summary: "Order Summary",
+      },
+      fulfillment: {
+        delivery: "Delivery",
+        deliveryDescription: "Have your meal brought straight to you.",
+        pickup: "Pickup",
+        pickupDescription: "Grab your order at the counter when it's ready.",
+      },
+      fields: {
+        firstName: "First Name",
+        lastName: "Last Name",
+        email: "Email",
+        phone: "Phone",
+        address: "Street Address",
+        city: "City",
+        zipCode: "ZIP Code",
+        paymentMethod: "Payment Method",
+        cardNumber: "Card Number",
+        expiryDate: "Expiry Date",
+        cvv: "CVV",
+      },
+      paymentMethods: {
+        card: "Credit/Debit Card",
+        cash: "Cash on Delivery",
+      },
+      placeholders: {
+        cardNumber: "1234 5678 9012 3456",
+        expiryDate: "MM/YY",
+        cvv: "123",
+      },
+      summary: {
+        fulfillment: "Fulfillment",
+        subtotal: "Subtotal",
+        deliveryFee: "Delivery Fee",
+        tax: "Tax",
+        total: "Total",
+      },
+      actions: {
+        placeOrder: "Place Order",
+        processing: "Processing...",
+      },
+      empty: {
+        title: "Your cart is empty",
+        subtitle: "Add a few delicious items before completing your order.",
+        cta: "Browse the menu",
+      },
+      notifications: {
+        success: "Order placed successfully!",
+        failure: "Failed to place order. Please try again.",
+      },
+      errors: {
+        firstName: "First name is required",
+        lastName: "Last name is required",
+        email: "Email is required",
+        phone: "Phone number is required",
+        address: "Address is required",
+        city: "City is required",
+        zipCode: "ZIP code is required",
+        paymentMethod: "Payment method is required",
+        cardNumber: "Card number is required",
+        expiryDate: "Expiry date is required",
+        cvv: "CVV is required",
+      },
+    },
     // Menu Page
     menuPage: {
       title: "Our Menu",
@@ -300,6 +372,78 @@ export const translations = {
       promoCode: "Code promo",
       proceedToCheckout: "Procéder au Paiement",
       continueShopping: "Continuer les Achats",
+    },
+    // Order Page
+    orderPage: {
+      title: "Finalisez Votre Commande",
+      sections: {
+        fulfillment: "Comment souhaitez-vous récupérer votre commande ?",
+        customerInformation: "Informations Client",
+        deliveryAddress: "Adresse de Livraison",
+        paymentMethod: "Mode de Paiement",
+        summary: "Récapitulatif de Commande",
+      },
+      fulfillment: {
+        delivery: "Livraison",
+        deliveryDescription: "Faites-vous livrer directement chez vous.",
+        pickup: "À emporter",
+        pickupDescription: "Récupérez votre commande au comptoir quand elle est prête.",
+      },
+      fields: {
+        firstName: "Prénom",
+        lastName: "Nom",
+        email: "Email",
+        phone: "Téléphone",
+        address: "Adresse",
+        city: "Ville",
+        zipCode: "Code Postal",
+        paymentMethod: "Mode de Paiement",
+        cardNumber: "Numéro de Carte",
+        expiryDate: "Date d'Expiration",
+        cvv: "CVV",
+      },
+      paymentMethods: {
+        card: "Carte de Crédit/Débit",
+        cash: "Paiement à la Livraison",
+      },
+      placeholders: {
+        cardNumber: "1234 5678 9012 3456",
+        expiryDate: "MM/AA",
+        cvv: "123",
+      },
+      summary: {
+        fulfillment: "Mode de retrait",
+        subtotal: "Sous-total",
+        deliveryFee: "Frais de Livraison",
+        tax: "Taxes",
+        total: "Total",
+      },
+      actions: {
+        placeOrder: "Passer la Commande",
+        processing: "Traitement...",
+      },
+      empty: {
+        title: "Votre panier est vide",
+        subtitle: "Ajoutez quelques délices avant de finaliser votre commande.",
+        cta: "Parcourir le menu",
+      },
+      notifications: {
+        success: "Commande passée avec succès !",
+        failure: "Échec de la commande. Veuillez réessayer.",
+      },
+      errors: {
+        firstName: "Le prénom est requis",
+        lastName: "Le nom est requis",
+        email: "L'email est requis",
+        phone: "Le numéro de téléphone est requis",
+        address: "L'adresse est requise",
+        city: "La ville est requise",
+        zipCode: "Le code postal est requis",
+        paymentMethod: "Le mode de paiement est requis",
+        cardNumber: "Le numéro de carte est requis",
+        expiryDate: "La date d'expiration est requise",
+        cvv: "Le CVV est requis",
+      },
     },
     // Menu Page
     menuPage: {
@@ -468,6 +612,78 @@ export const translations = {
       proceedToCheckout: "Zur Kasse Gehen",
       continueShopping: "Weiter Einkaufen",
     },
+    // Order Page
+    orderPage: {
+      title: "Schließen Sie Ihre Bestellung Ab",
+      sections: {
+        fulfillment: "Wie möchten Sie Ihre Bestellung erhalten?",
+        customerInformation: "Kundendaten",
+        deliveryAddress: "Lieferadresse",
+        paymentMethod: "Zahlungsmethode",
+        summary: "Bestellübersicht",
+      },
+      fulfillment: {
+        delivery: "Lieferung",
+        deliveryDescription: "Lassen Sie sich das Essen direkt nach Hause bringen.",
+        pickup: "Abholung",
+        pickupDescription: "Holen Sie Ihre Bestellung ab, sobald sie fertig ist.",
+      },
+      fields: {
+        firstName: "Vorname",
+        lastName: "Nachname",
+        email: "E-Mail",
+        phone: "Telefon",
+        address: "Straße und Hausnummer",
+        city: "Stadt",
+        zipCode: "PLZ",
+        paymentMethod: "Zahlungsmethode",
+        cardNumber: "Kartennummer",
+        expiryDate: "Ablaufdatum",
+        cvv: "CVV",
+      },
+      paymentMethods: {
+        card: "Kredit-/Debitkarte",
+        cash: "Barzahlung bei Lieferung",
+      },
+      placeholders: {
+        cardNumber: "1234 5678 9012 3456",
+        expiryDate: "MM/JJ",
+        cvv: "123",
+      },
+      summary: {
+        fulfillment: "Art der Zustellung",
+        subtotal: "Zwischensumme",
+        deliveryFee: "Liefergebühr",
+        tax: "Steuer",
+        total: "Gesamt",
+      },
+      actions: {
+        placeOrder: "Bestellung Abschicken",
+        processing: "Wird verarbeitet...",
+      },
+      empty: {
+        title: "Ihr Warenkorb ist leer",
+        subtitle: "Fügen Sie ein paar Leckereien hinzu, bevor Sie die Bestellung abschließen.",
+        cta: "Menü ansehen",
+      },
+      notifications: {
+        success: "Bestellung erfolgreich aufgegeben!",
+        failure: "Bestellung fehlgeschlagen. Bitte versuche es erneut.",
+      },
+      errors: {
+        firstName: "Vorname ist erforderlich",
+        lastName: "Nachname ist erforderlich",
+        email: "E-Mail ist erforderlich",
+        phone: "Telefonnummer ist erforderlich",
+        address: "Adresse ist erforderlich",
+        city: "Stadt ist erforderlich",
+        zipCode: "PLZ ist erforderlich",
+        paymentMethod: "Zahlungsmethode ist erforderlich",
+        cardNumber: "Kartennummer ist erforderlich",
+        expiryDate: "Ablaufdatum ist erforderlich",
+        cvv: "CVV ist erforderlich",
+      },
+    },
     // Menu Page
     menuPage: {
       title: "Unser Menü",
@@ -500,5 +716,15 @@ export const translations = {
   },
 } as const
 
+type DotNestedKeys<T> = T extends object
+  ? {
+      [K in Extract<keyof T, string>]: T[K] extends object
+        ? `${K}` | `${K}.${DotNestedKeys<T[K]>}`
+        : `${K}`
+    }[Extract<keyof T, string>]
+  : never
+
 export type Language = keyof typeof translations
-export type TranslationKey = keyof typeof translations.en
+export type TranslationSchema = (typeof translations)[Language]
+export type TranslationKey = DotNestedKeys<TranslationSchema>
+export type FoodKey = keyof TranslationSchema["food"]


### PR DESCRIPTION
## Summary
- introduce a shared cart context and client providers so menu, home, and order flows share the same state
- wire menu cards, cart page, and new cart status button to the shared cart with storage-backed counts
- refresh the order form with delivery vs pickup selection, localized empty state messaging, and updated translations

## Testing
- npm run lint *(fails: Next.js experimental.ppr requires canary build)*

------
https://chatgpt.com/codex/tasks/task_e_68f5ed40311c832fbe0b2a56c5e8987f