### PR TITLE
Fix German classic pizzas label

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -494,7 +494,7 @@ export const translations = {
       new: "NEU",
       off: "RABATT",
       specialtyPizzas: "Spezialitäten Pizzas",
-      classicPizzas: "Klassische Pizzas",
+      classicPizzas: "Klassische Pizzen",
       vegetarian: "Vegetarisch",
     },
   },


### PR DESCRIPTION
## Summary
- update the German translation for the classic pizzas label to use the correct plural form

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5f21ffc94832f92f8aee949680f0a