### PR TITLE
Add animation frame cleanup to animated background

### DIFF
--- a/src/components/animated-background.tsx
+++ b/src/components/animated-background.tsx
@@ -40,6 +40,8 @@ export function AnimatedBackground() {
       })
     }
 
+    let animationFrameId = 0
+
     function animate() {
       if (!ctx || !canvas) return
 
@@ -59,7 +61,7 @@ export function AnimatedBackground() {
         ctx.fill()
       })
 
-      requestAnimationFrame(animate)
+      animationFrameId = requestAnimationFrame(animate)
     }
 
     animate()
@@ -70,7 +72,10 @@ export function AnimatedBackground() {
     }
 
     window.addEventListener("resize", handleResize)
-    return () => window.removeEventListener("resize", handleResize)
+    return () => {
+      window.removeEventListener("resize", handleResize)
+      cancelAnimationFrame(animationFrameId)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- store the requestAnimationFrame identifier in the animated background effect
- cancel the outstanding animation frame during cleanup while keeping the dependency array unchanged

## Testing
- npm run lint *(fails: next binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5f2237be8832fb9d854d4ec398a4d