### PR TITLE
Add drinks and desserts categories to menu catalog

### DIFF
--- a/app/api/menu/route.ts
+++ b/app/api/menu/route.ts
@@ -1,37 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 
-// Sample menu data
-const menuData = {
-  pizzas: [
-    {
-      id: 101,
-      name: "Spicy Kebab Pizza",
-      description: "Our signature pizza topped with juicy kebab meat, jalapeños, and special spicy sauce",
-      price: 14.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Specialty Pizzas",
-      rating: 4.8,
-      popular: true,
-      ingredients: ["kebab meat", "jalapeños", "mozzarella", "tomato sauce", "spicy sauce"],
-      allergens: ["gluten", "dairy"],
-    },
-    // Add more items...
-  ],
-  kebabs: [
-    {
-      id: 201,
-      name: "Mixed Grill Kebab",
-      description: "A delicious mix of chicken, beef, and lamb kebab with grilled vegetables",
-      price: 16.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Kebabs",
-      rating: 4.7,
-      ingredients: ["chicken", "beef", "lamb", "grilled vegetables", "rice"],
-      allergens: [],
-    },
-    // Add more items...
-  ],
-}
+import { menuCatalog } from "@/data/menu-catalog"
 
 // Next.js 15: GET route handler
 export async function GET(request: NextRequest) {
@@ -41,7 +10,8 @@ export async function GET(request: NextRequest) {
     const limit = searchParams.get("limit")
     const sort = searchParams.get("sort")
 
-    let data = category ? menuData[category as keyof typeof menuData] || [] : Object.values(menuData).flat()
+    const catalogValues = Object.values(menuCatalog)
+    let data = category ? menuCatalog[category] || [] : catalogValues.flat()
 
     // Apply sorting
     if (sort === "price-low") {

--- a/app/menu/[category]/page.tsx
+++ b/app/menu/[category]/page.tsx
@@ -4,42 +4,12 @@ import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
 import { LanguageProvider } from "@/contexts/language-context"
+import { menuCatalog, validMenuCategories } from "@/data/menu-catalog"
 
 // Next.js 15: params is now a Promise
 type Props = {
   params: Promise<{ category: string }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
-}
-
-const validCategories = ["pizzas", "kebabs", "wraps", "sides", "drinks", "desserts"]
-
-const categoryItems = {
-  pizzas: [
-    {
-      id: 101,
-      name: "Spicy Kebab Pizza",
-      description: "Our signature pizza topped with juicy kebab meat, jalapeños, and special spicy sauce",
-      price: 14.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Specialty Pizzas",
-      rating: 4.8,
-      popular: true,
-    },
-    // Add more items...
-  ],
-  kebabs: [
-    {
-      id: 201,
-      name: "Mixed Grill Kebab",
-      description: "A delicious mix of chicken, beef, and lamb kebab with grilled vegetables",
-      price: 16.99,
-      image: "/placeholder.svg?height=300&width=300",
-      category: "Kebabs",
-      rating: 4.7,
-    },
-    // Add more items...
-  ],
-  // Add other categories...
 }
 
 export default async function CategoryPage(props: Props) {
@@ -50,11 +20,11 @@ export default async function CategoryPage(props: Props) {
   const { category } = params
   const { sort, filter } = searchParams
 
-  if (!validCategories.includes(category)) {
+  if (!validMenuCategories.includes(category)) {
     notFound()
   }
 
-  const items = categoryItems[category as keyof typeof categoryItems] || []
+  const items = menuCatalog[category] || []
 
   return (
     <LanguageProvider>
@@ -106,7 +76,7 @@ export default async function CategoryPage(props: Props) {
 
 // Next.js 15: generateStaticParams for static generation
 export async function generateStaticParams() {
-  return validCategories.map((category) => ({
+  return validMenuCategories.map((category) => ({
     category,
   }))
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
+    "test": "node --import tsx --test tests/menu-catalog.test.ts",
     "analyze": "ANALYZE=true npm run build"
   },
   "dependencies": {

--- a/src/app/menu/MenuClientPage.tsx
+++ b/src/app/menu/MenuClientPage.tsx
@@ -131,6 +131,46 @@ function MenuContent() {
         rating: 4.2,
       },
     ],
+    drinks: [
+      {
+        id: 501,
+        name: t("food.classicCola.name"),
+        description: t("food.classicCola.description"),
+        price: 2.99,
+        image: "/placeholder.svg?height=300&width=300",
+        category: t("categories.drinks"),
+        rating: 4.2,
+      },
+      {
+        id: 502,
+        name: t("food.sparklingWater.name"),
+        description: t("food.sparklingWater.description"),
+        price: 2.49,
+        image: "/placeholder.svg?height=300&width=300",
+        category: t("categories.drinks"),
+        rating: 4.0,
+      },
+    ],
+    desserts: [
+      {
+        id: 601,
+        name: t("food.baklava.name"),
+        description: t("food.baklava.description"),
+        price: 4.99,
+        image: "/placeholder.svg?height=300&width=300",
+        category: t("categories.desserts"),
+        rating: 4.6,
+      },
+      {
+        id: 602,
+        name: t("food.tiramisu.name"),
+        description: t("food.tiramisu.description"),
+        price: 5.99,
+        image: "/placeholder.svg?height=300&width=300",
+        category: t("categories.desserts"),
+        rating: 4.7,
+      },
+    ],
   }
 
   return (
@@ -163,6 +203,12 @@ function MenuContent() {
               <TabsTrigger value="sides" className="text-lg py-2 px-4">
                 {t("categories.sides")}
               </TabsTrigger>
+              <TabsTrigger value="drinks" className="text-lg py-2 px-4">
+                {t("categories.drinks")}
+              </TabsTrigger>
+              <TabsTrigger value="desserts" className="text-lg py-2 px-4">
+                {t("categories.desserts")}
+              </TabsTrigger>
             </TabsList>
 
             <TabsContent value="pizzas">
@@ -192,6 +238,22 @@ function MenuContent() {
             <TabsContent value="sides">
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                 {menuItems.sides.map((item) => (
+                  <InteractiveMenuCard key={item.id} item={item} />
+                ))}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="drinks">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {menuItems.drinks.map((item) => (
+                  <InteractiveMenuCard key={item.id} item={item} />
+                ))}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="desserts">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {menuItems.desserts.map((item) => (
                   <InteractiveMenuCard key={item.id} item={item} />
                 ))}
               </div>

--- a/src/components/category-section.tsx
+++ b/src/components/category-section.tsx
@@ -6,56 +6,21 @@ import { ArrowRight, Flame } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
+import { menuCatalog } from "@/data/menu-catalog"
 
 export function CategorySection() {
   const { t } = useLanguage()
 
-  const categories = [
-    {
-      id: 1,
-      name: t("categories.pizzas"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 12,
-      href: "/menu/pizzas",
-      featured: true,
-    },
-    {
-      id: 2,
-      name: t("categories.kebabs"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 8,
-      href: "/menu/kebabs",
-      featured: true,
-    },
-    {
-      id: 3,
-      name: t("categories.wraps"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 6,
-      href: "/menu/wraps",
-    },
-    {
-      id: 4,
-      name: t("categories.sides"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 10,
-      href: "/menu/sides",
-    },
-    {
-      id: 5,
-      name: t("categories.drinks"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 15,
-      href: "/menu/drinks",
-    },
-    {
-      id: 6,
-      name: t("categories.desserts"),
-      image: "/placeholder.svg?height=400&width=400",
-      count: 7,
-      href: "/menu/desserts",
-    },
-  ]
+  const categoryOrder = ["pizzas", "kebabs", "wraps", "sides", "drinks", "desserts"] as const
+
+  const categories = categoryOrder.map((slug, index) => ({
+    id: index + 1,
+    name: t(`categories.${slug}`),
+    image: "/placeholder.svg?height=400&width=400",
+    count: menuCatalog[slug]?.length ?? 0,
+    href: `/menu/${slug}`,
+    featured: slug === "pizzas" || slug === "kebabs",
+  }))
 
   return (
     <section className="py-16 bg-white relative">

--- a/src/data/menu-catalog.ts
+++ b/src/data/menu-catalog.ts
@@ -1,0 +1,178 @@
+export interface MenuCatalogItem {
+  id: number
+  name: string
+  description: string
+  price: number
+  image: string
+  category: string
+  rating: number
+  popular?: boolean
+  discount?: number
+}
+
+export type MenuCatalog = Record<string, MenuCatalogItem[]>
+
+export const menuCatalog: MenuCatalog = {
+  pizzas: [
+    {
+      id: 101,
+      name: "Spicy Kebab Pizza",
+      description: "Our signature pizza topped with juicy kebab meat, jalapeños, and special spicy sauce",
+      price: 14.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Specialty Pizzas",
+      rating: 4.8,
+      popular: true,
+    },
+    {
+      id: 102,
+      name: "Margherita",
+      description: "Classic pizza with tomato sauce, mozzarella, and fresh basil",
+      price: 11.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Classic Pizzas",
+      rating: 4.6,
+    },
+    {
+      id: 103,
+      name: "Meat Feast Pizza",
+      description: "Loaded with pepperoni, sausage, bacon, and ground beef for meat lovers",
+      price: 15.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Specialty Pizzas",
+      rating: 4.9,
+      discount: 10,
+    },
+    {
+      id: 104,
+      name: "Veggie Supreme",
+      description: "Fresh vegetables including peppers, onions, mushrooms, and olives",
+      price: 13.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Vegetarian",
+      rating: 4.4,
+    },
+  ],
+  kebabs: [
+    {
+      id: 201,
+      name: "Mixed Grill Kebab",
+      description: "A delicious mix of chicken, beef, and lamb kebab with grilled vegetables",
+      price: 16.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Kebabs",
+      rating: 4.7,
+    },
+    {
+      id: 202,
+      name: "Chicken Shish",
+      description: "Marinated chicken pieces grilled to perfection",
+      price: 13.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Kebabs",
+      rating: 4.5,
+    },
+    {
+      id: 203,
+      name: "Lamb Kofte",
+      description: "Seasoned minced lamb formed into kebabs and grilled",
+      price: 14.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Kebabs",
+      rating: 4.8,
+      discount: 15,
+    },
+    {
+      id: 204,
+      name: "Vegetable Kebab",
+      description: "Grilled seasonal vegetables with halloumi cheese",
+      price: 12.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Vegetarian",
+      rating: 4.3,
+    },
+  ],
+  wraps: [
+    {
+      id: 301,
+      name: "Chicken Shawarma Wrap",
+      description: "Tender chicken shawarma with fresh vegetables and garlic sauce in a warm wrap",
+      price: 9.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Wraps",
+      rating: 4.6,
+    },
+    {
+      id: 302,
+      name: "Lamb Doner Wrap",
+      description: "Sliced lamb doner with lettuce, tomato, onion, and tzatziki sauce",
+      price: 10.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Wraps",
+      rating: 4.4,
+    },
+  ],
+  sides: [
+    {
+      id: 401,
+      name: "Garlic Cheese Bread",
+      description: "Freshly baked bread topped with garlic butter and melted cheese",
+      price: 5.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Sides",
+      rating: 4.5,
+    },
+    {
+      id: 402,
+      name: "Spicy Potato Wedges",
+      description: "Crispy potato wedges seasoned with spicy herbs",
+      price: 4.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Sides",
+      rating: 4.2,
+    },
+  ],
+  drinks: [
+    {
+      id: 501,
+      name: "Classic Cola",
+      description: "Refreshing fizzy cola served chilled.",
+      price: 2.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Drinks",
+      rating: 4.2,
+      popular: true,
+    },
+    {
+      id: 502,
+      name: "Sparkling Water",
+      description: "Lightly carbonated mineral water with a slice of lemon.",
+      price: 2.49,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Drinks",
+      rating: 4.0,
+    },
+  ],
+  desserts: [
+    {
+      id: 601,
+      name: "Baklava",
+      description: "Layers of flaky pastry with nuts and honey syrup.",
+      price: 4.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Desserts",
+      rating: 4.6,
+    },
+    {
+      id: 602,
+      name: "Tiramisu",
+      description: "Classic Italian dessert with mascarpone and espresso-soaked ladyfingers.",
+      price: 5.99,
+      image: "/placeholder.svg?height=300&width=300",
+      category: "Desserts",
+      rating: 4.7,
+    },
+  ],
+} satisfies MenuCatalog
+
+export const validMenuCategories = Object.keys(menuCatalog)

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -105,6 +105,22 @@ export const translations = {
         name: "Spicy Potato Wedges",
         description: "Crispy potato wedges seasoned with spicy herbs",
       },
+      classicCola: {
+        name: "Classic Cola",
+        description: "Refreshing fizzy cola served chilled.",
+      },
+      sparklingWater: {
+        name: "Sparkling Water",
+        description: "Lightly carbonated mineral water with a slice of lemon.",
+      },
+      baklava: {
+        name: "Baklava",
+        description: "Layers of flaky pastry with nuts and honey syrup.",
+      },
+      tiramisu: {
+        name: "Tiramisu",
+        description: "Classic Italian dessert with mascarpone and espresso-soaked ladyfingers.",
+      },
     },
     // Testimonials
     testimonials: {
@@ -270,6 +286,22 @@ export const translations = {
       spicyPotatoWedges: {
         name: "Quartiers de Pommes de Terre Épicés",
         description: "Quartiers de pommes de terre croustillants assaisonnés aux herbes épicées",
+      },
+      classicCola: {
+        name: "Cola Classique",
+        description: "Cola pétillant rafraîchissant servi bien frais.",
+      },
+      sparklingWater: {
+        name: "Eau Pétillante",
+        description: "Eau minérale légèrement gazeuse avec une tranche de citron.",
+      },
+      baklava: {
+        name: "Baklava",
+        description: "Couches de pâte feuilletée avec des noix et du sirop de miel.",
+      },
+      tiramisu: {
+        name: "Tiramisu",
+        description: "Dessert italien classique au mascarpone et biscuits imbibés d'espresso.",
       },
     },
     // Testimonials
@@ -437,6 +469,22 @@ export const translations = {
       spicyPotatoWedges: {
         name: "Würzige Kartoffelecken",
         description: "Knusprige Kartoffelecken gewürzt mit würzigen Kräutern",
+      },
+      classicCola: {
+        name: "Klassische Cola",
+        description: "Erfrischende spritzige Cola, gekühlt serviert.",
+      },
+      sparklingWater: {
+        name: "Sprudelwasser",
+        description: "Leicht kohlensäurehaltiges Mineralwasser mit einer Zitronenscheibe.",
+      },
+      baklava: {
+        name: "Baklava",
+        description: "Schichten aus Blätterteig mit Nüssen und Honigsirup.",
+      },
+      tiramisu: {
+        name: "Tiramisu",
+        description: "Klassisches italienisches Dessert mit Mascarpone und Espresso-getränkten Löffelbiskuits.",
       },
     },
     // Testimonials

--- a/tests/menu-catalog.test.ts
+++ b/tests/menu-catalog.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { menuCatalog, validMenuCategories } from "@/data/menu-catalog"
+
+const expectedCategories = ["pizzas", "kebabs", "wraps", "sides", "drinks", "desserts"]
+
+describe("menuCatalog", () => {
+  it("exposes all expected categories", () => {
+    expectedCategories.forEach((category) => {
+      assert.ok(
+        validMenuCategories.includes(category),
+        `Category ${category} should be present in validMenuCategories`,
+      )
+      assert.ok(Array.isArray(menuCatalog[category]), `Category ${category} should resolve to an array`)
+    })
+  })
+
+  it("provides data for drinks and desserts", () => {
+    const drinks = menuCatalog.drinks
+    const desserts = menuCatalog.desserts
+
+    assert.ok(drinks.length > 0, "Drinks catalog should contain at least one item")
+    assert.ok(desserts.length > 0, "Desserts catalog should contain at least one item")
+  })
+})


### PR DESCRIPTION
## Summary
- centralize the menu catalog data and add drinks and desserts items for category routing and API usage
- update the category section, menu tabs, and translations so drinks and desserts appear throughout the UI
- add a node:test-based check for the catalog and wire it into the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f6211f15b4832faaeff8bc4f084287