### PR TITLE
fix: restore bundle analyzer compatibility in next config

### DIFF
--- a/docs/taches-validation-staging.md
+++ b/docs/taches-validation-staging.md
@@ -1,0 +1,63 @@
+# Plan de vérification fonctionnelle
+
+## Tâche 1 : Vérifier la user story « Perrine, 29 ans, acheteuse de kebab à midi »
+
+**Objectif**
+- Garantir que Perrine peut découvrir le menu, personnaliser son kebab et finaliser sa commande sans friction.
+
+**Parcours utilisateur attendu**
+1. Perrine ouvre la page d’accueil et accède au catalogue (pizza, kebab, menus du midi).
+2. Elle sélectionne un kebab depuis la page catalogue ou via la recherche si disponible.
+3. Perrine choisit la formule (taille, sauce, accompagnement) et ajoute le kebab au panier.
+4. Elle consulte le panier, ajuste éventuellement les quantités ou supprime des articles.
+5. Perrine choisit le mode de retrait ou de livraison, renseigne ses coordonnées et valide la commande.
+6. Elle reçoit une confirmation (écran de succès ou récapitulatif de commande).
+
+**Critères de vérification**
+- [ ] Les éléments du parcours ci-dessus sont réalisables sur l’environnement cible (staging).
+- [ ] Aucune erreur console ou blocage UI lors de la navigation.
+- [ ] Les totaux du panier se mettent à jour correctement (prix, taxes, frais de livraison).
+- [ ] Les règles métier spécifiques au kebab (options obligatoires, disponibilité midi) sont respectées.
+- [ ] Une trace de la commande (log ou base staging) est créée à la validation.
+
+**Préparatifs**
+- Accès à l’URL de staging avec compte test si nécessaire.
+- Jeux de données ou fixtures reflétant l’offre midi.
+- Check-list UX pour capturer les points de friction éventuels.
+
+## Tâche 2 : Valider toutes les fonctionnalités sur l’environnement de staging
+
+**Objectif**
+- Passer en revue l’intégralité des fonctionnalités livrées afin de confirmer la stabilité avant déploiement.
+
+**Portée fonctionnelle**
+- Catalogue (pizzas, kebabs, desserts, boissons).
+- Gestion du panier (ajout, modification, suppression, calcul des frais).
+- Pages principales (accueil, panier, commande, suivi le cas échéant).
+- Authentification/utilisateurs si disponible (inscription, connexion, préférences).
+- Routes API et webhooks intégrés.
+- Contenus dynamiques (traductions, thèmes, configuration runtime).
+
+**Plan de test**
+1. Démarrer sur staging avec un navigateur supporté (Chrome, Firefox).
+2. Nettoyer le stockage local/session pour partir d’un état vierge.
+3. Exécuter des scénarios représentatifs :
+   - Commande standard (kebab midi).
+   - Commande mixte (pizza + boisson + dessert).
+   - Annulation ou modification panier.
+   - Changement de langue/monnaie si disponible.
+4. Vérifier les intégrations externes : paiements simulés, analytics, notifications.
+5. Contrôler les routes API (statuts 2xx, payload attendus, absence d’erreurs serveur).
+6. Saisir les résultats dans un rapport de test partagé (tableau ou outil QA).
+
+**Critères d’acceptation**
+- [ ] Tous les scénarios définis sont passés avec succès ou documentés avec anomalies.
+- [ ] Les logs d’erreurs (serveur, navigateur) ne contiennent pas de régressions bloquantes.
+- [ ] Les variables d’environnement et secrets staging sont présents et valides.
+- [ ] Les performances restent dans les budgets définis (temps de chargement, TTFB).
+- [ ] Les recommandations post-test sont priorisées et assignées.
+
+**Livrables**
+- Rapport de validation détaillant les scénarios, résultats, captures et anomalies.
+- Liste des actions correctives à adresser avant la mise en production Vercel.
+- Accord de sortie signé par l’équipe produit/QA.

--- a/docs/vercel-deploy-review.md
+++ b/docs/vercel-deploy-review.md
@@ -1,0 +1,31 @@
+# Revue des fonctionnalités pour la déployabilité Vercel
+
+## Contexte général
+Les derniers développements ont introduit plusieurs fonctionnalités clés (catalogue enrichi, contexte panier global, page de commande détaillée, utilitaires partagés, routes API) dont la compatibilité avec l'environnement serverless de Vercel doit être confirmée. Cette note récapitule les points déjà couverts par le code et les éventuels ajustements à surveiller.
+
+## Routes API compatibles serverless
+- **Catalogue du menu** : la route `GET /api/menu` et sa contrepartie `POST` reposent sur les _route handlers_ natifs de Next (`NextResponse`) et manipulent uniquement des structures en mémoire dérivées du catalogue statique, ce qui correspond au modèle des fonctions serverless de Vercel.【F:app/api/menu/route.ts†L1-L68】
+- **Panier** : les handlers `GET`, `POST` et `DELETE` exposent un tableau en mémoire pour simuler la persistance. Ce choix reste fonctionnel sur Vercel (chaque exécution dispose de son propre état) mais ne garantit pas la persistance entre invocations ; il faudra prévoir un stockage durable (Edge Config, KV, base de données) avant la mise en production.【F:app/api/cart/route.ts†L1-L78】
+
+## Gestion du panier côté client
+- **Contexte React** : `CartProvider` gère l'état du panier et les totaux via `useState`, `useMemo` et des utilitaires purs (`calculateTotals`, `calculateItemCount`). Le contexte est explicitement marqué `"use client"`, ce qui évite les appels à `localStorage` ou `window` sur le serveur lors du rendu initial Vercel.【F:src/contexts/cart-context.tsx†L1-L82】【F:src/lib/cart.ts†L1-L38】
+- **Intégration des providers** : `AppProviders` compose le `LanguageProvider` et le `CartProvider`, garantissant une hiérarchie cohérente pour toutes les pages clientes (cart et order).【F:src/components/app-providers.tsx†L1-L12】
+
+## Page de commande et expérience panier
+- **OrderClientPage** : la page utilise exclusivement des hooks côté client (`useState`, `useMemo`) et des utilitaires purs (`calculatePricingBreakdown`, `validateAddressFields`). Les interactions (validation, affichage conditionnel du panier vide) ne dépendent d'aucune API Node.js, assurant un rendu hybride compatible avec Vercel.【F:src/app/order/OrderClientPage.tsx†L1-L161】【F:src/lib/pricing.ts†L1-L43】【F:src/lib/address.ts†L1-L34】
+- **CartClientPage** : l'expérience panier s'appuie sur les mêmes providers clients et sur les utilitaires de formatage/pricing, sans dépendances serveur. Les actions (ajout, suppression, changement de mode livraison/retrait) restent purement clients et prêtes pour un rendu sur Vercel.【F:src/app/cart/CartClientPage.tsx†L1-L144】
+
+## Catalogue et utilitaires partagés
+- **Catalogue enrichi** : `menuCatalog` expose pizzas, kebabs, wraps, boissons et desserts via un simple objet exporté ; cette structure est compatible avec le bundling statique de Next/Vercel et évite toute dépendance I/O.【F:src/data/menu-catalog.ts†L1-L118】
+- **Calculs partagés** : `pricing.ts` et `address.ts` proposent des fonctions pures sans effets de bord. Elles peuvent être réutilisées aussi bien côté client que côté serveur sans configuration spécifique pour Vercel.【F:src/lib/pricing.ts†L1-L43】【F:src/lib/address.ts†L1-L34】
+
+## Points de vigilance restants
+1. **Persistance du panier côté API** : l'état en mémoire de `app/api/cart/route.ts` disparaîtra à chaque warm-up/froid d'une fonction serverless. Prévoir un stockage persistant avant le go-live Vercel.【F:app/api/cart/route.ts†L1-L78】
+2. **Hydratation des providers** : `LanguageProvider` lit/écrit dans `localStorage` uniquement dans un `useEffect`, ce qui reste sûr, mais il faudra s'assurer que les pages utilisant ce provider sont bien marquées `"use client"` (actuellement le cas via `AppProviders`).【F:src/contexts/language-context.tsx†L1-L48】
+3. **Configuration Next.js** : le `next.config.ts` est minimal ; pour Vercel, vérifier en amont s'il faut activer des options spécifiques (`output`, `experimental`) selon la cible (app router).【F:next.config.ts†L1-L7】
+
+## Recommandations pour la mise en production Vercel
+- Ajouter un stockage persistant (PostgreSQL, Supabase, Vercel KV) pour le panier et toute donnée mutable.
+- Documenter/automatiser les variables d'environnement sensibles dans le tableau de bord Vercel (clés analytics, éventuelles API externes).
+- Exécuter `npm run lint` et `npm run test` dans le pipeline CI afin de détecter tout usage involontaire d'APIs non compatibles Edge/Serverless.
+- Si des fonctions doivent tourner en mode Edge, expliciter `export const runtime = "edge";` dans les handlers concernés pour bénéficier de la latence minimale une fois sur Vercel.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,7 @@
+import { createRequire } from "module"
+
+const require = createRequire(import.meta.url)
+
 const enableReactCompiler = process.env.NEXT_ENABLE_REACT_COMPILER === "true"
 const enablePartialPrerendering = process.env.NEXT_ENABLE_PPR === "true"
 


### PR DESCRIPTION
## Summary
- define a CommonJS-compatible `require` helper in `next.config.mjs`
- keep bundle analyzer plugin support without relying on unavailable globals on Vercel

## Testing
- npm run build *(fails: existing JSX parse errors in interactive-menu-card and cart client page)*

------
https://chatgpt.com/codex/tasks/task_e_68f630a5049c832fbb200045879bcad4