### PR TITLE
Restore menu card UI and integrate Fastify APIs

### DIFF
--- a/app/menu/[category]/CategoryMenuClient.tsx
+++ b/app/menu/[category]/CategoryMenuClient.tsx
@@ -1,28 +1,46 @@
 "use client"
 
-import { useMemo } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { InteractiveMenuCard } from "@/components/interactive-menu-card"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
 import { useLanguage } from "@/contexts/language-context"
-import {
-  getLocalizedMenuSections,
-  getMenuCategoryLabelKey,
-  type MenuCategory,
-} from "@/lib/menu-data"
+import { Button } from "@/components/ui/button"
+import { fetchMenus, type MenuApi } from "@/lib/api/menu"
+import { buildCategoryMap, isKnownCategory } from "@/lib/menu-transform"
 
 interface CategoryMenuClientProps {
-  category: MenuCategory
+  category: string
 }
 
 export function CategoryMenuClient({ category }: CategoryMenuClientProps) {
   const { t } = useLanguage()
+  const [menus, setMenus] = useState<MenuApi[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
 
-  const menuSections = useMemo(() => getLocalizedMenuSections(t), [t])
-  const items = menuSections[category] ?? []
-  const categoryLabel = t(getMenuCategoryLabelKey(category))
+  const loadMenu = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const response = await fetchMenus()
+      setMenus(response.menus.filter((menu) => menu.isActive))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load menu")
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadMenu()
+  }, [loadMenu])
+
+  const sections = useMemo(() => buildCategoryMap(menus, t), [menus, t])
+  const items = sections[category] ?? []
+  const categoryLabel = isKnownCategory(category) ? t(`categories.${category}` as const) : category
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -40,31 +58,50 @@ export function CategoryMenuClient({ category }: CategoryMenuClientProps) {
         <div className="container py-8">
           <h1 className="text-4xl font-bold mb-8 capitalize">{categoryLabel}</h1>
 
-          <div className="flex gap-4 mb-8">
-            <select className="px-4 py-2 border rounded-lg">
-              <option value="">Sort by</option>
-              <option value="price-low">Price: Low to High</option>
-              <option value="price-high">Price: High to Low</option>
-              <option value="rating">Rating</option>
-              <option value="popular">Popularity</option>
-            </select>
+          {isLoading ? (
+            <div className="py-16 text-center text-muted-foreground">Loading items…</div>
+          ) : error ? (
+            <div className="py-16 text-center space-y-4">
+              <p className="text-red-600 font-semibold">{t("checkout.failure")}</p>
+              <p className="text-muted-foreground">{error}</p>
+              <Button onClick={() => void loadMenu()} variant="outline" className="rounded-full">
+                Retry
+              </Button>
+            </div>
+          ) : items.length === 0 ? (
+            <div className="py-16 text-center space-y-2 text-muted-foreground">
+              <p>No items available in this category.</p>
+            </div>
+          ) : (
+            <>
+              <div className="flex gap-4 mb-8">
+                <select className="px-4 py-2 border rounded-lg">
+                  <option value="">Sort by</option>
+                  <option value="price-low">Price: Low to High</option>
+                  <option value="price-high">Price: High to Low</option>
+                  <option value="rating">Rating</option>
+                  <option value="popular">Popularity</option>
+                </select>
 
-            <select className="px-4 py-2 border rounded-lg">
-              <option value="">All Items</option>
-              <option value="vegetarian">Vegetarian</option>
-              <option value="spicy">Spicy</option>
-              <option value="new">New Items</option>
-            </select>
-          </div>
+                <select className="px-4 py-2 border rounded-lg">
+                  <option value="">All Items</option>
+                  <option value="vegetarian">Vegetarian</option>
+                  <option value="spicy">Spicy</option>
+                  <option value="new">New Items</option>
+                </select>
+              </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {items.map((item) => (
-              <InteractiveMenuCard key={item.id} item={item} />
-            ))}
-          </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {items.map((item) => (
+                  <InteractiveMenuCard key={`${category}-${item.id}`} item={item} />
+                ))}
+              </div>
+            </>
+          )}
         </div>
       </main>
       <Footer />
     </div>
   )
 }
+

--- a/app/menu/[category]/page.tsx
+++ b/app/menu/[category]/page.tsx
@@ -1,89 +1,42 @@
 import { notFound } from "next/navigation"
-import { InteractiveMenuCard } from "@/components/interactive-menu-card"
-import { MainNav } from "@/components/main-nav"
-import { MobileNav } from "@/components/mobile-nav"
-import { Footer } from "@/components/footer"
-import { AppProviders } from "@/components/app-providers"
 
-type Props = {
-  params: Promise<{ category: string }>
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+import { AppProviders } from "@/components/app-providers"
+import { CATEGORY_ORDER, isKnownCategory } from "@/lib/menu-transform"
+
+import { CategoryMenuClient } from "./CategoryMenuClient"
+
+const STATIC_CATEGORIES = CATEGORY_ORDER as readonly string[]
+
+interface CategoryPageProps {
+  params: { category: string }
 }
 
-export default async function CategoryPage(props: Props) {
-  const params = await props.params
-  await props.searchParams
+export default function CategoryPage({ params }: CategoryPageProps) {
+  const category = params.category.toLowerCase()
 
-  const categoryParam = params.category as MenuCategory
-
-  if (!validMenuCategories.includes(category)) {
+  if (!STATIC_CATEGORIES.includes(category)) {
     notFound()
   }
 
-  const items = menuCatalog[category] || []
-
   return (
     <AppProviders>
-      <div className="flex min-h-screen flex-col">
-        <header className="sticky top-0 z-50 w-full border-b bg-background">
-          <div className="container flex h-16 items-center justify-between">
-            <div className="hidden md:flex">
-              <MainNav />
-            </div>
-            <div className="md:hidden">
-              <MobileNav />
-            </div>
-          </div>
-        </header>
-        <main className="flex-1">
-          <div className="container py-8">
-            <h1 className="text-4xl font-bold mb-8 capitalize">{category}</h1>
-
-            {/* Filter and sort options */}
-            <div className="flex gap-4 mb-8">
-              <select className="px-4 py-2 border rounded-lg">
-                <option value="">Sort by</option>
-                <option value="price-low">Price: Low to High</option>
-                <option value="price-high">Price: High to Low</option>
-                <option value="rating">Rating</option>
-                <option value="popular">Popularity</option>
-              </select>
-
-              <select className="px-4 py-2 border rounded-lg">
-                <option value="">All Items</option>
-                <option value="vegetarian">Vegetarian</option>
-                <option value="spicy">Spicy</option>
-                <option value="new">New Items</option>
-              </select>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {items.map((item) => (
-                <InteractiveMenuCard key={item.id} item={item} />
-              ))}
-            </div>
-          </div>
-        </main>
-        <Footer />
-      </div>
+      <CategoryMenuClient category={category} />
     </AppProviders>
   )
 }
 
-export async function generateStaticParams() {
-  return validMenuCategories.map((category) => ({
-    category,
-  }))
+export function generateStaticParams() {
+  return STATIC_CATEGORIES.map((category) => ({ category }))
 }
 
-export async function generateMetadata(props: Props) {
-  const params = await props.params
-  const { category } = params
-
-  const capitalizedCategory = category.charAt(0).toUpperCase() + category.slice(1)
+export function generateMetadata({ params }: CategoryPageProps) {
+  const category = params.category
+  const label = isKnownCategory(category) ? category : category
+  const capitalized = label.charAt(0).toUpperCase() + label.slice(1)
 
   return {
-    title: `${capitalizedCategory} - PizzaKebab`,
-    description: `Explore our delicious ${category} menu at PizzaKebab.`,
+    title: `${capitalized} - PizzaKebab`,
+    description: `Explore our delicious ${label} menu at PizzaKebab.`,
   }
 }
+

--- a/services/api/src/db/schemas.ts
+++ b/services/api/src/db/schemas.ts
@@ -8,6 +8,7 @@ export interface BaseDocument {
 export interface MenuDocument extends BaseDocument {
   name: string;
   description?: string;
+  translationKey?: string;
   isActive: boolean;
 }
 
@@ -15,9 +16,17 @@ export interface MenuItemDocument extends BaseDocument {
   menuId: string;
   name: string;
   description?: string;
+  nameKey?: string;
+  descriptionKey?: string;
+  categoryKey?: string;
   price: number;
   currency: string;
   isAvailable: boolean;
+  imageUrl?: string;
+  rating?: number;
+  discountPercentage?: number;
+  isPopular?: boolean;
+  isNew?: boolean;
 }
 
 export interface CartItem {
@@ -28,8 +37,11 @@ export interface CartItem {
 
 export interface CartDocument extends BaseDocument {
   deviceId: string;
+  sessionId?: string;
+  userId?: string;
   status: 'open' | 'checked_out';
   items: CartItem[];
+  promoCode?: string | null;
 }
 
 export interface OrderDocument extends BaseDocument {
@@ -38,6 +50,16 @@ export interface OrderDocument extends BaseDocument {
   total: number;
   currency: string;
   submittedAt: Date;
+  promoCode?: string | null;
+  items: CartItem[];
+  deliveryFee?: number;
+  discountTotal?: number;
+  customer?: {
+    name?: string;
+    phone?: string;
+    email?: string;
+  };
+  notes?: string;
 }
 
 export interface DeviceDocument extends BaseDocument {

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -4,6 +4,9 @@ import { randomUUID } from 'crypto';
 import { config } from './config';
 import mongoPlugin from './plugins/mongo';
 import tenantResolverPlugin from './plugins/tenant-resolver';
+import menusRoutes from './routes/menus';
+import cartsRoutes from './routes/carts';
+import ordersRoutes from './routes/orders';
 
 const logger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
@@ -21,6 +24,9 @@ export const buildServer = (): FastifyInstance => {
 
   app.register(mongoPlugin);
   app.register(tenantResolverPlugin);
+  app.register(menusRoutes);
+  app.register(cartsRoutes);
+  app.register(ordersRoutes);
 
   app.get('/healthz', async () => ({ status: 'ok' }));
 

--- a/services/api/src/plugins/mongo.ts
+++ b/services/api/src/plugins/mongo.ts
@@ -1,9 +1,12 @@
 import fp from 'fastify-plugin';
 import { FastifyInstance, FastifyRequest } from 'fastify';
 import { ensureIndexes, getTenantCollections, closeMongo, TenantCollections } from '../db/mongo';
+import { config } from '../config';
+import { seedTenantData } from '../seed';
 
 export const mongoPlugin = fp(async (fastify: FastifyInstance) => {
   await ensureIndexes();
+  await seedTenantData(Object.values(config.tenantHostMap), fastify.log);
   fastify.decorate('getTenantCollections', getTenantCollections);
   fastify.decorateRequest('getTenantCollections', async function (this: FastifyRequest): Promise<TenantCollections> {
     if (!this.tenantId) {

--- a/services/api/src/plugins/tenant-resolver.ts
+++ b/services/api/src/plugins/tenant-resolver.ts
@@ -3,6 +3,14 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { config } from '../config';
 
 const resolveTenantId = (request: FastifyRequest): string | null => {
+  const tenantHeader = request.headers['x-tenant-id'] ?? request.headers['x-tenant'];
+  if (tenantHeader) {
+    if (Array.isArray(tenantHeader)) {
+      return tenantHeader[0];
+    }
+    return tenantHeader;
+  }
+
   const hostHeader = request.headers.host;
   if (!hostHeader) {
     return null;

--- a/services/api/src/routes/carts.ts
+++ b/services/api/src/routes/carts.ts
@@ -1,0 +1,327 @@
+import { FastifyInstance } from 'fastify';
+import { randomUUID } from 'crypto';
+
+import { CartItem } from '../db/schemas';
+import { buildCartSummary, serializeCart } from '../services/cart';
+
+type CreateCartBody = {
+  deviceId?: string;
+  sessionId?: string;
+  userId?: string;
+  promoCode?: string;
+};
+
+type UpdateCartBody = {
+  items?: Array<{
+    menuItemId: string;
+    quantity: number;
+    notes?: string;
+  }>;
+  promoCode?: string | null;
+};
+
+const promotionSchema = {
+  type: ['object', 'null'],
+  properties: {
+    code: { type: 'string' },
+    amount: { type: 'number' },
+    type: { type: 'string' },
+    description: { type: 'string' },
+  },
+  required: ['code', 'amount', 'type'],
+  additionalProperties: false,
+} as const;
+
+const hydratedMenuItemSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    menuId: { type: 'string' },
+    name: { type: 'string' },
+    nameKey: { type: 'string' },
+    description: { type: 'string' },
+    descriptionKey: { type: 'string' },
+    categoryKey: { type: 'string' },
+    price: { type: 'number' },
+    currency: { type: 'string' },
+    imageUrl: { type: 'string' },
+    rating: { type: 'number' },
+    discountPercentage: { type: 'number' },
+    isPopular: { type: 'boolean' },
+    isNew: { type: 'boolean' },
+    isAvailable: { type: 'boolean' },
+  },
+  required: ['id', 'menuId', 'name', 'price', 'currency', 'isAvailable'],
+  additionalProperties: false,
+} as const;
+
+const cartItemSchema = {
+  type: 'object',
+  properties: {
+    menuItemId: { type: 'string' },
+    quantity: { type: 'integer' },
+    notes: { type: 'string' },
+    menuItem: { type: ['object', 'null'], anyOf: [hydratedMenuItemSchema, { type: 'null' }] },
+  },
+  required: ['menuItemId', 'quantity'],
+  additionalProperties: false,
+} as const;
+
+const cartTotalsSchema = {
+  type: 'object',
+  properties: {
+    subtotal: { type: 'number' },
+    deliveryFee: { type: 'number' },
+    discount: { type: 'number' },
+    total: { type: 'number' },
+    currency: { type: 'string' },
+  },
+  required: ['subtotal', 'deliveryFee', 'discount', 'total', 'currency'],
+  additionalProperties: false,
+} as const;
+
+const cartResponseSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    deviceId: { type: 'string' },
+    sessionId: { type: ['string', 'null'] },
+    userId: { type: ['string', 'null'] },
+    status: { type: 'string', enum: ['open', 'checked_out'] },
+    promoCode: { type: ['string', 'null'] },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+    items: { type: 'array', items: cartItemSchema },
+    totals: cartTotalsSchema,
+    promotion: promotionSchema,
+  },
+  required: ['id', 'deviceId', 'status', 'createdAt', 'updatedAt', 'items', 'totals'],
+  additionalProperties: false,
+} as const;
+
+const responseSchema = {
+  200: {
+    type: 'object',
+    properties: {
+      cart: cartResponseSchema,
+    },
+    required: ['cart'],
+  },
+} as const;
+
+const createCartBodySchema = {
+  type: 'object',
+  properties: {
+    deviceId: { type: 'string', minLength: 1 },
+    sessionId: { type: 'string', minLength: 1 },
+    userId: { type: 'string', minLength: 1 },
+    promoCode: { type: 'string', minLength: 1 },
+  },
+  additionalProperties: false,
+  anyOf: [{ required: ['deviceId'] }, { required: ['sessionId'] }, { required: ['userId'] }],
+} as const;
+
+const cartItemInputSchema = {
+  type: 'object',
+  properties: {
+    menuItemId: { type: 'string', minLength: 1 },
+    quantity: { type: 'integer', minimum: 0 },
+    notes: { type: 'string' },
+  },
+  required: ['menuItemId', 'quantity'],
+  additionalProperties: false,
+} as const;
+
+const updateCartBodySchema = {
+  type: 'object',
+  properties: {
+    items: { type: 'array', items: cartItemInputSchema, maxItems: 100 },
+    promoCode: { type: ['string', 'null'] },
+  },
+  additionalProperties: false,
+} as const;
+
+const cartParamsSchema = {
+  type: 'object',
+  properties: {
+    cartId: { type: 'string', minLength: 1 },
+  },
+  required: ['cartId'],
+  additionalProperties: false,
+} as const;
+
+const normalizeItems = (items: UpdateCartBody['items']): CartItem[] => {
+  if (!items || items.length === 0) {
+    return [];
+  }
+
+  const aggregated = new Map<string, { quantity: number; notes?: string }>();
+  for (const item of items) {
+    const menuItemId = String(item.menuItemId);
+    if (!menuItemId) {
+      continue;
+    }
+
+    const normalizedQuantity = Math.max(0, Math.min(Number.isFinite(item.quantity) ? Math.floor(item.quantity) : 0, 99));
+    if (normalizedQuantity <= 0) {
+      continue;
+    }
+
+    const existing = aggregated.get(menuItemId);
+    aggregated.set(menuItemId, {
+      quantity: (existing?.quantity ?? 0) + normalizedQuantity,
+      notes: item.notes ?? existing?.notes,
+    });
+  }
+
+  return Array.from(aggregated.entries()).map(([menuItemId, payload]) => ({
+    menuItemId,
+    quantity: payload.quantity,
+    notes: payload.notes,
+  }));
+};
+
+const ensureCart = async (
+  app: FastifyInstance,
+  tenantId: string,
+  body: CreateCartBody,
+) => {
+  const collections = await app.getTenantCollections(tenantId);
+
+  const filter: Record<string, unknown> = { status: 'open' };
+  if (body.deviceId) {
+    filter.deviceId = body.deviceId;
+  }
+  if (body.sessionId) {
+    filter.sessionId = body.sessionId;
+  }
+  if (body.userId) {
+    filter.userId = body.userId;
+  }
+
+  let cart = await collections.carts.findOne(filter);
+
+  if (!cart) {
+    const resourceId = randomUUID();
+    await collections.carts.insertOne({
+      resourceId,
+      deviceId: body.deviceId ?? body.sessionId ?? resourceId,
+      sessionId: body.sessionId,
+      userId: body.userId,
+      status: 'open',
+      items: [],
+      promoCode: body.promoCode ?? null,
+    });
+    cart = await collections.carts.findOne({ resourceId });
+  } else if (body.promoCode && cart.promoCode !== body.promoCode) {
+    await collections.carts.updateOne(
+      { resourceId: cart.resourceId },
+      { $set: { promoCode: body.promoCode } },
+    );
+    cart = await collections.carts.findOne({ resourceId: cart.resourceId });
+  }
+
+  if (!cart) {
+    throw new Error('Failed to resolve cart');
+  }
+
+  const summary = await buildCartSummary(collections, cart);
+  return serializeCart(cart, summary);
+};
+
+export default async function cartsRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Body: CreateCartBody }>(
+    '/carts',
+    {
+      schema: {
+        body: createCartBodySchema,
+        response: responseSchema,
+      },
+    },
+    async (request) => {
+      const cart = await ensureCart(app, request.tenantId, request.body);
+      return { cart };
+    },
+  );
+
+  app.get(
+    '/carts/:cartId',
+    {
+      schema: {
+        params: cartParamsSchema,
+        response: responseSchema,
+      },
+    },
+    async (request, reply) => {
+      const { cartId } = request.params as { cartId: string };
+      const collections = await request.getTenantCollections();
+      const cart = await collections.carts.findOne({ resourceId: cartId });
+
+      if (!cart) {
+        reply.code(404);
+        return { message: 'Cart not found' };
+      }
+
+      if (cart.status !== 'open') {
+        reply.code(409);
+        return { message: 'Cart is no longer active' };
+      }
+
+      const summary = await buildCartSummary(collections, cart);
+      return { cart: serializeCart(cart, summary) };
+    },
+  );
+
+  app.put<{ Params: { cartId: string }; Body: UpdateCartBody }>(
+    '/carts/:cartId',
+    {
+      schema: {
+        params: cartParamsSchema,
+        body: updateCartBodySchema,
+        response: responseSchema,
+      },
+    },
+    async (request, reply) => {
+      const { cartId } = request.params;
+      const collections = await request.getTenantCollections();
+      const cart = await collections.carts.findOne({ resourceId: cartId });
+
+      if (!cart) {
+        reply.code(404);
+        return { message: 'Cart not found' };
+      }
+
+      if (cart.status !== 'open') {
+        reply.code(409);
+        return { message: 'Cart is no longer active' };
+      }
+
+      const updatePayload: Record<string, unknown> = {};
+
+      if (request.body.items) {
+        updatePayload.items = normalizeItems(request.body.items);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(request.body, 'promoCode')) {
+        updatePayload.promoCode = request.body.promoCode ? request.body.promoCode : null;
+      }
+
+      if (Object.keys(updatePayload).length > 0) {
+        await collections.carts.updateOne(
+          { resourceId: cartId },
+          { $set: updatePayload },
+        );
+      }
+
+      const updatedCart = await collections.carts.findOne({ resourceId: cartId });
+      if (!updatedCart) {
+        reply.code(500);
+        return { message: 'Failed to update cart' };
+      }
+
+      const summary = await buildCartSummary(collections, updatedCart);
+      return { cart: serializeCart(updatedCart, summary) };
+    },
+  );
+}
+

--- a/services/api/src/routes/menus.ts
+++ b/services/api/src/routes/menus.ts
@@ -1,0 +1,125 @@
+import { FastifyInstance } from 'fastify';
+
+import { MenuDocument, MenuItemDocument } from '../db/schemas';
+
+const menuItemSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    legacyId: { type: 'integer' },
+    menuId: { type: 'string' },
+    name: { type: 'string' },
+    description: { type: 'string' },
+    nameKey: { type: 'string' },
+    descriptionKey: { type: 'string' },
+    categoryKey: { type: 'string' },
+    price: { type: 'number' },
+    currency: { type: 'string' },
+    imageUrl: { type: 'string' },
+    rating: { type: 'number' },
+    discountPercentage: { type: 'number' },
+    isPopular: { type: 'boolean' },
+    isNew: { type: 'boolean' },
+    isAvailable: { type: 'boolean' },
+  },
+  required: ['id', 'menuId', 'price', 'currency', 'isAvailable'],
+  additionalProperties: false,
+} as const;
+
+const menuSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    description: { type: 'string' },
+    translationKey: { type: 'string' },
+    isActive: { type: 'boolean' },
+    items: { type: 'array', items: menuItemSchema },
+  },
+  required: ['id', 'name', 'isActive', 'items'],
+  additionalProperties: false,
+} as const;
+
+const formatMenuItem = (doc: MenuItemDocument) => {
+  const legacyId = Number.parseInt(doc.resourceId, 10);
+  return {
+    id: doc.resourceId,
+    legacyId: Number.isFinite(legacyId) ? legacyId : undefined,
+    menuId: doc.menuId,
+    name: doc.name,
+    description: doc.description,
+    nameKey: doc.nameKey,
+    descriptionKey: doc.descriptionKey,
+    categoryKey: doc.categoryKey,
+    price: doc.price,
+    currency: doc.currency,
+    imageUrl: doc.imageUrl,
+    rating: doc.rating,
+    discountPercentage: doc.discountPercentage,
+    isPopular: doc.isPopular ?? false,
+    isNew: doc.isNew ?? false,
+    isAvailable: doc.isAvailable,
+  };
+};
+
+const formatMenu = (doc: MenuDocument, items: MenuItemDocument[]) => ({
+  id: doc.resourceId,
+  name: doc.name,
+  description: doc.description,
+  translationKey: doc.translationKey,
+  isActive: doc.isActive,
+  items: items
+    .map(formatMenuItem)
+    .sort((a, b) => {
+      if (a.legacyId && b.legacyId) {
+        return a.legacyId - b.legacyId;
+      }
+      return a.name.localeCompare(b.name);
+    }),
+});
+
+const responseSchema = {
+  200: {
+    type: 'object',
+    properties: {
+      menus: {
+        type: 'array',
+        items: menuSchema,
+      },
+    },
+    required: ['menus'],
+  },
+} as const;
+
+export default async function menusRoutes(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/menus',
+    {
+      schema: {
+        response: responseSchema,
+      },
+    },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+
+      const [menus, menuItems] = await Promise.all([
+        collections.menus.find({ isActive: true }).toArray(),
+        collections.menuItems.find({}).toArray(),
+      ]);
+
+      const itemsByMenu = new Map<string, MenuItemDocument[]>();
+      for (const item of menuItems) {
+        const list = itemsByMenu.get(item.menuId) ?? [];
+        list.push(item);
+        itemsByMenu.set(item.menuId, list);
+      }
+
+      const payload = menus
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((menu) => formatMenu(menu, itemsByMenu.get(menu.resourceId) ?? []));
+
+      return { menus: payload };
+    },
+  );
+}
+

--- a/services/api/src/routes/orders.ts
+++ b/services/api/src/routes/orders.ts
@@ -1,0 +1,180 @@
+import { FastifyInstance } from 'fastify';
+import { randomUUID } from 'crypto';
+
+import { buildCartSummary } from '../services/cart';
+import { enqueueKitchenTicket } from '../services/kitchen-queue';
+
+type SubmitOrderBody = {
+  cartId: string;
+  promoCode?: string | null;
+  notes?: string;
+  customer?: {
+    name?: string;
+    phone?: string;
+    email?: string;
+  };
+};
+
+const customerSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    phone: { type: 'string' },
+    email: { type: 'string' },
+  },
+  additionalProperties: false,
+} as const;
+
+const promotionSchema = {
+  type: ['object', 'null'],
+  properties: {
+    code: { type: 'string' },
+    amount: { type: 'number' },
+    type: { type: 'string' },
+    description: { type: 'string' },
+  },
+  required: ['code', 'amount', 'type'],
+  additionalProperties: false,
+} as const;
+
+const cartTotalsSchema = {
+  type: 'object',
+  properties: {
+    subtotal: { type: 'number' },
+    deliveryFee: { type: 'number' },
+    discount: { type: 'number' },
+    total: { type: 'number' },
+    currency: { type: 'string' },
+  },
+  required: ['subtotal', 'deliveryFee', 'discount', 'total', 'currency'],
+  additionalProperties: false,
+} as const;
+
+const submitOrderBodySchema = {
+  type: 'object',
+  properties: {
+    cartId: { type: 'string', minLength: 1 },
+    promoCode: { type: ['string', 'null'] },
+    notes: { type: 'string' },
+    customer: customerSchema,
+  },
+  required: ['cartId'],
+  additionalProperties: false,
+} as const;
+
+const orderResponseSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    cartId: { type: 'string' },
+    status: { type: 'string' },
+    total: { type: 'number' },
+    currency: { type: 'string' },
+    submittedAt: { type: 'string', format: 'date-time' },
+    promotion: promotionSchema,
+    totals: cartTotalsSchema,
+  },
+  required: ['id', 'cartId', 'status', 'total', 'currency', 'submittedAt', 'totals'],
+  additionalProperties: false,
+} as const;
+
+export default async function ordersRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Body: SubmitOrderBody }>(
+    '/orders',
+    {
+      schema: {
+        body: submitOrderBodySchema,
+        response: {
+          201: {
+            type: 'object',
+            properties: {
+              order: orderResponseSchema,
+            },
+            required: ['order'],
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { cartId, promoCode, notes, customer } = request.body;
+      const collections = await request.getTenantCollections();
+      let cart = await collections.carts.findOne({ resourceId: cartId });
+
+      if (!cart) {
+        reply.code(404);
+        return { message: 'Cart not found' };
+      }
+
+      if (cart.status !== 'open') {
+        reply.code(409);
+        return { message: 'Cart is no longer active' };
+      }
+
+      if (promoCode && cart.promoCode !== promoCode) {
+        await collections.carts.updateOne(
+          { resourceId: cart.resourceId },
+          { $set: { promoCode } },
+        );
+        cart = await collections.carts.findOne({ resourceId: cart.resourceId });
+      }
+
+      if (!cart) {
+        reply.code(404);
+        return { message: 'Cart not found' };
+      }
+
+      const summary = await buildCartSummary(collections, cart);
+      const resourceId = randomUUID();
+      const submittedAt = new Date();
+
+      await collections.orders.insertOne({
+        resourceId,
+        cartId,
+        status: 'pending',
+        total: summary.totals.total,
+        currency: summary.totals.currency,
+        submittedAt,
+        promoCode: summary.promotion?.code ?? cart.promoCode ?? null,
+        items: summary.items.map(({ menuItemId, quantity, notes: lineNotes }) => ({
+          menuItemId,
+          quantity,
+          notes: lineNotes,
+        })),
+        deliveryFee: summary.totals.deliveryFee,
+        discountTotal: summary.totals.discount,
+        customer,
+        notes,
+      });
+
+      await collections.carts.updateOne(
+        { resourceId: cartId },
+        { $set: { status: 'checked_out' } },
+      );
+
+      await enqueueKitchenTicket(request.log, {
+        orderId: resourceId,
+        cartId,
+        tenantId: request.tenantId,
+        items: summary.items,
+        totals: summary.totals,
+        customer,
+        notes,
+      });
+
+      reply.code(201);
+      return {
+        order: {
+          id: resourceId,
+          cartId,
+          status: 'pending',
+          total: summary.totals.total,
+          currency: summary.totals.currency,
+          submittedAt: submittedAt.toISOString(),
+          promotion: summary.promotion ?? null,
+          totals: summary.totals,
+        },
+      };
+    },
+  );
+}
+

--- a/services/api/src/seed/index.ts
+++ b/services/api/src/seed/index.ts
@@ -1,0 +1,73 @@
+import type { FastifyBaseLogger } from 'fastify';
+
+import { getTenantCollections } from '../db/mongo';
+import { menuFixtures } from './menu-fixtures';
+
+const normalizeTenantIds = (tenantIds: string[]): string[] => {
+  const unique = new Set(tenantIds.filter(Boolean));
+  if (unique.size === 0) {
+    unique.add('pizzakebab');
+  }
+  return Array.from(unique);
+};
+
+export const seedTenantData = async (tenantIds: string[], logger: FastifyBaseLogger): Promise<void> => {
+  const ids = normalizeTenantIds(tenantIds);
+
+  for (const tenantId of ids) {
+    try {
+      const collections = await getTenantCollections(tenantId);
+
+      for (const menu of menuFixtures) {
+        await collections.menus.updateOne(
+          { resourceId: menu.resourceId },
+          {
+            $setOnInsert: {
+              resourceId: menu.resourceId,
+              createdAt: new Date(),
+            },
+            $set: {
+              name: menu.name,
+              description: menu.description,
+              translationKey: menu.translationKey,
+              isActive: menu.isActive,
+            },
+          },
+          { upsert: true },
+        );
+
+        for (const item of menu.items) {
+          await collections.menuItems.updateOne(
+            { resourceId: item.resourceId },
+            {
+              $setOnInsert: {
+                resourceId: item.resourceId,
+                createdAt: new Date(),
+              },
+              $set: {
+                menuId: menu.resourceId,
+                name: item.name,
+                description: item.description,
+                nameKey: item.nameKey,
+                descriptionKey: item.descriptionKey,
+                categoryKey: item.categoryKey,
+                price: item.price,
+                currency: item.currency,
+                isAvailable: true,
+                imageUrl: item.imageUrl,
+                rating: item.rating,
+                discountPercentage: item.discountPercentage,
+                isPopular: item.isPopular,
+                isNew: item.isNew,
+              },
+            },
+            { upsert: true },
+          );
+        }
+      }
+    } catch (error) {
+      logger.error({ err: error, tenantId }, 'failed to seed tenant data');
+    }
+  }
+};
+

--- a/services/api/src/seed/menu-fixtures.ts
+++ b/services/api/src/seed/menu-fixtures.ts
@@ -1,0 +1,292 @@
+export interface MenuItemFixture {
+  resourceId: string;
+  name: string;
+  description?: string;
+  nameKey: string;
+  descriptionKey: string;
+  categoryKey: string;
+  price: number;
+  currency: string;
+  imageUrl?: string;
+  rating?: number;
+  discountPercentage?: number;
+  isPopular?: boolean;
+  isNew?: boolean;
+}
+
+export interface MenuFixture {
+  resourceId: string;
+  name: string;
+  description?: string;
+  translationKey: string;
+  isActive: boolean;
+  items: MenuItemFixture[];
+}
+
+const BASE_IMAGE = '/placeholder.svg?height=300&width=300';
+
+export const menuFixtures: MenuFixture[] = [
+  {
+    resourceId: 'pizzas',
+    name: 'Pizzas',
+    description: 'Handcrafted pizzas with bold Mediterranean flavours.',
+    translationKey: 'categories.pizzas',
+    isActive: true,
+    items: [
+      {
+        resourceId: '101',
+        name: 'Spicy Kebab Pizza',
+        description: 'Signature pizza topped with juicy kebab meat and special spicy sauce.',
+        nameKey: 'food.spicyKebabPizza.name',
+        descriptionKey: 'food.spicyKebabPizza.description',
+        categoryKey: 'common.specialtyPizzas',
+        price: 14.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.8,
+        isPopular: true,
+      },
+      {
+        resourceId: '102',
+        name: 'Margherita',
+        description: 'Classic pizza with tomato sauce, mozzarella and fresh basil.',
+        nameKey: 'food.margherita.name',
+        descriptionKey: 'food.margherita.description',
+        categoryKey: 'common.classicPizzas',
+        price: 11.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.6,
+      },
+      {
+        resourceId: '103',
+        name: 'Meat Feast Pizza',
+        description: 'Loaded with pepperoni, sausage, bacon and ground beef.',
+        nameKey: 'food.meatFeastPizza.name',
+        descriptionKey: 'food.meatFeastPizza.description',
+        categoryKey: 'common.specialtyPizzas',
+        price: 15.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        discountPercentage: 10,
+        rating: 4.9,
+      },
+      {
+        resourceId: '104',
+        name: 'Veggie Supreme',
+        description: 'Topped with peppers, onions, mushrooms and olives.',
+        nameKey: 'food.veggieSupreme.name',
+        descriptionKey: 'food.veggieSupreme.description',
+        categoryKey: 'common.vegetarian',
+        price: 13.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.4,
+      },
+    ],
+  },
+  {
+    resourceId: 'kebabs',
+    name: 'Kebabs',
+    description: 'Char-grilled kebabs served with fresh accompaniments.',
+    translationKey: 'categories.kebabs',
+    isActive: true,
+    items: [
+      {
+        resourceId: '201',
+        name: 'Mixed Grill Kebab',
+        description: 'A mix of chicken, beef and lamb kebab with grilled vegetables.',
+        nameKey: 'food.mixedGrillKebab.name',
+        descriptionKey: 'food.mixedGrillKebab.description',
+        categoryKey: 'categories.kebabs',
+        price: 16.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.7,
+      },
+      {
+        resourceId: '202',
+        name: 'Chicken Shish',
+        description: 'Marinated chicken pieces grilled to perfection.',
+        nameKey: 'food.chickenShish.name',
+        descriptionKey: 'food.chickenShish.description',
+        categoryKey: 'categories.kebabs',
+        price: 13.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.5,
+      },
+      {
+        resourceId: '203',
+        name: 'Lamb Kofte',
+        description: 'Seasoned minced lamb formed into kebabs and grilled.',
+        nameKey: 'food.lambKofte.name',
+        descriptionKey: 'food.lambKofte.description',
+        categoryKey: 'categories.kebabs',
+        price: 14.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        discountPercentage: 15,
+        rating: 4.8,
+      },
+      {
+        resourceId: '204',
+        name: 'Vegetable Kebab',
+        description: 'Grilled seasonal vegetables with halloumi cheese.',
+        nameKey: 'food.vegetableKebab.name',
+        descriptionKey: 'food.vegetableKebab.description',
+        categoryKey: 'common.vegetarian',
+        price: 12.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.3,
+      },
+    ],
+  },
+  {
+    resourceId: 'wraps',
+    name: 'Wraps',
+    description: 'Warm wraps packed with bold fillings.',
+    translationKey: 'categories.wraps',
+    isActive: true,
+    items: [
+      {
+        resourceId: '301',
+        name: 'Chicken Shawarma Wrap',
+        description: 'Tender chicken shawarma with vegetables and garlic sauce.',
+        nameKey: 'food.chickenShawarmaWrap.name',
+        descriptionKey: 'food.chickenShawarmaWrap.description',
+        categoryKey: 'categories.wraps',
+        price: 9.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.6,
+      },
+      {
+        resourceId: '302',
+        name: 'Lamb Doner Wrap',
+        description: 'Sliced lamb doner with lettuce, tomato and tzatziki.',
+        nameKey: 'food.lambDonerWrap.name',
+        descriptionKey: 'food.lambDonerWrap.description',
+        categoryKey: 'categories.wraps',
+        price: 10.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.4,
+      },
+      {
+        resourceId: '303',
+        name: 'Falafel Wrap',
+        description: 'Crispy falafel with tahini sauce and fresh vegetables.',
+        nameKey: 'food.falafelWrap.name',
+        descriptionKey: 'food.falafelWrap.description',
+        categoryKey: 'common.vegetarian',
+        price: 8.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.4,
+        isNew: true,
+      },
+    ],
+  },
+  {
+    resourceId: 'sides',
+    name: 'Sides',
+    description: 'Perfect complements to any meal.',
+    translationKey: 'categories.sides',
+    isActive: true,
+    items: [
+      {
+        resourceId: '401',
+        name: 'Garlic Cheese Bread',
+        description: 'Freshly baked bread topped with garlic butter and cheese.',
+        nameKey: 'food.garlicCheeseBread.name',
+        descriptionKey: 'food.garlicCheeseBread.description',
+        categoryKey: 'categories.sides',
+        price: 5.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.5,
+      },
+      {
+        resourceId: '402',
+        name: 'Spicy Potato Wedges',
+        description: 'Crispy potato wedges seasoned with spicy herbs.',
+        nameKey: 'food.spicyPotatoWedges.name',
+        descriptionKey: 'food.spicyPotatoWedges.description',
+        categoryKey: 'categories.sides',
+        price: 4.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.2,
+      },
+    ],
+  },
+  {
+    resourceId: 'drinks',
+    name: 'Drinks',
+    description: 'Refreshments to keep you cool.',
+    translationKey: 'categories.drinks',
+    isActive: true,
+    items: [
+      {
+        resourceId: '501',
+        name: 'Classic Cola',
+        description: 'Refreshing fizzy cola served chilled.',
+        nameKey: 'food.classicCola.name',
+        descriptionKey: 'food.classicCola.description',
+        categoryKey: 'categories.drinks',
+        price: 2.99,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.1,
+      },
+      {
+        resourceId: '502',
+        name: 'Sparkling Water',
+        description: 'Lightly carbonated mineral water with a slice of lemon.',
+        nameKey: 'food.sparklingWater.name',
+        descriptionKey: 'food.sparklingWater.description',
+        categoryKey: 'categories.drinks',
+        price: 2.49,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.0,
+      },
+    ],
+  },
+  {
+    resourceId: 'desserts',
+    name: 'Desserts',
+    description: 'Sweet treats to finish your meal.',
+    translationKey: 'categories.desserts',
+    isActive: true,
+    items: [
+      {
+        resourceId: '601',
+        name: 'Baklava',
+        description: 'Layers of flaky pastry with nuts and honey syrup.',
+        nameKey: 'food.baklava.name',
+        descriptionKey: 'food.baklava.description',
+        categoryKey: 'categories.desserts',
+        price: 4.49,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.7,
+      },
+      {
+        resourceId: '602',
+        name: 'Tiramisu',
+        description: 'Classic Italian dessert with mascarpone and espresso.',
+        nameKey: 'food.tiramisu.name',
+        descriptionKey: 'food.tiramisu.description',
+        categoryKey: 'categories.desserts',
+        price: 5.49,
+        currency: 'USD',
+        imageUrl: BASE_IMAGE,
+        rating: 4.6,
+      },
+    ],
+  },
+];
+

--- a/services/api/src/services/cart.ts
+++ b/services/api/src/services/cart.ts
@@ -1,0 +1,172 @@
+import { Filter } from 'mongodb';
+
+import { TenantCollections } from '../db/mongo';
+import { CartDocument, CartItem, MenuItemDocument } from '../db/schemas';
+import { AppliedPromotion, evaluatePromoCode } from './promotions';
+
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_DELIVERY_FEE = 2.99;
+
+export interface HydratedMenuItem {
+  id: string;
+  menuId: string;
+  name: string;
+  nameKey?: string;
+  description?: string;
+  descriptionKey?: string;
+  categoryKey?: string;
+  price: number;
+  currency: string;
+  imageUrl?: string;
+  rating?: number;
+  discountPercentage?: number;
+  isPopular?: boolean;
+  isNew?: boolean;
+  isAvailable: boolean;
+}
+
+export interface HydratedCartItem extends CartItem {
+  menuItem?: HydratedMenuItem;
+}
+
+export interface CartTotals {
+  subtotal: number;
+  deliveryFee: number;
+  discount: number;
+  total: number;
+  currency: string;
+}
+
+export interface CartSummary {
+  items: HydratedCartItem[];
+  totals: CartTotals;
+  promotion?: AppliedPromotion;
+}
+
+const sanitizeCartItems = (items: CartItem[]): CartItem[] =>
+  items.filter((item) => Number.isFinite(item.quantity) && item.quantity > 0);
+
+const hydrateCartItems = async (
+  collections: TenantCollections,
+  items: CartItem[],
+): Promise<HydratedCartItem[]> => {
+  const sanitized = sanitizeCartItems(items);
+
+  if (sanitized.length === 0) {
+    return [];
+  }
+
+  const menuItemIds = sanitized.map((item) => item.menuItemId);
+  const menuItems = await collections.menuItems
+    .find({ resourceId: { $in: menuItemIds } } as Filter<MenuItemDocument>)
+    .toArray();
+
+  const menuItemMap = new Map(menuItems.map((doc) => [doc.resourceId, doc]));
+
+  return sanitized.map((item) => {
+    const doc = menuItemMap.get(item.menuItemId);
+    if (!doc) {
+      return { ...item };
+    }
+
+    const hydratedMenuItem: HydratedMenuItem = {
+      id: doc.resourceId,
+      menuId: doc.menuId,
+      name: doc.name,
+      nameKey: doc.nameKey,
+      description: doc.description,
+      descriptionKey: doc.descriptionKey,
+      categoryKey: doc.categoryKey,
+      price: doc.price,
+      currency: doc.currency,
+      imageUrl: doc.imageUrl,
+      rating: doc.rating,
+      discountPercentage: doc.discountPercentage,
+      isPopular: doc.isPopular,
+      isNew: doc.isNew,
+      isAvailable: doc.isAvailable,
+    };
+
+    return {
+      ...item,
+      menuItem: hydratedMenuItem,
+    };
+  });
+};
+
+const roundCurrency = (value: number): number => Number(value.toFixed(2));
+
+export const buildCartSummary = async (
+  collections: TenantCollections,
+  cart: CartDocument,
+): Promise<CartSummary> => {
+  const items = await hydrateCartItems(collections, cart.items ?? []);
+
+  let subtotal = 0;
+  let currency = DEFAULT_CURRENCY;
+
+  for (const item of items) {
+    if (item.menuItem && item.menuItem.isAvailable) {
+      subtotal += item.menuItem.price * item.quantity;
+      currency = item.menuItem.currency ?? currency;
+    }
+  }
+
+  const deliveryFee = items.length > 0 ? DEFAULT_DELIVERY_FEE : 0;
+  const promoResult = evaluatePromoCode(cart.promoCode, subtotal, deliveryFee);
+  const discount = promoResult.appliedPromotion?.amount ?? 0;
+  const total = Math.max(subtotal + deliveryFee - discount, 0);
+
+  return {
+    items,
+    totals: {
+      subtotal: roundCurrency(subtotal),
+      deliveryFee: roundCurrency(deliveryFee),
+      discount: roundCurrency(discount),
+      total: roundCurrency(total),
+      currency,
+    },
+    promotion: promoResult.appliedPromotion,
+  };
+};
+
+export interface SerializedCartItem {
+  menuItemId: string;
+  quantity: number;
+  notes?: string;
+  menuItem?: HydratedMenuItem;
+}
+
+export interface SerializedCart {
+  id: string;
+  deviceId: string;
+  sessionId?: string;
+  userId?: string;
+  status: CartDocument['status'];
+  promoCode?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items: SerializedCartItem[];
+  totals: CartTotals;
+  promotion?: AppliedPromotion;
+}
+
+export const serializeCart = (cart: CartDocument, summary: CartSummary): SerializedCart => ({
+  id: cart.resourceId,
+  deviceId: cart.deviceId,
+  sessionId: cart.sessionId,
+  userId: cart.userId,
+  status: cart.status,
+  promoCode: cart.promoCode ?? null,
+  createdAt: cart.createdAt.toISOString(),
+  updatedAt: cart.updatedAt.toISOString(),
+  items: summary.items.map((item) => ({
+    menuItemId: item.menuItemId,
+    quantity: item.quantity,
+    notes: item.notes,
+    menuItem: item.menuItem,
+  })),
+  totals: summary.totals,
+  promotion: summary.promotion,
+});
+

--- a/services/api/src/services/kitchen-queue.ts
+++ b/services/api/src/services/kitchen-queue.ts
@@ -1,0 +1,35 @@
+import type { FastifyBaseLogger } from 'fastify';
+
+import type { HydratedCartItem, CartTotals } from './cart';
+
+export interface KitchenTicket {
+  orderId: string;
+  cartId: string;
+  tenantId: string;
+  items: HydratedCartItem[];
+  totals: CartTotals;
+  customer?: {
+    name?: string;
+    phone?: string;
+    email?: string;
+  };
+  notes?: string;
+  enqueuedAt: string;
+}
+
+const inMemoryQueue: KitchenTicket[] = [];
+
+export const enqueueKitchenTicket = async (
+  logger: FastifyBaseLogger,
+  ticket: Omit<KitchenTicket, 'enqueuedAt'>,
+): Promise<void> => {
+  const payload: KitchenTicket = {
+    ...ticket,
+    enqueuedAt: new Date().toISOString(),
+  };
+  inMemoryQueue.push(payload);
+  logger.info({ kitchenTicket: payload }, 'kitchen ticket enqueued');
+};
+
+export const getQueuedKitchenTickets = (): KitchenTicket[] => [...inMemoryQueue];
+

--- a/services/api/src/services/promotions.ts
+++ b/services/api/src/services/promotions.ts
@@ -1,0 +1,118 @@
+export type PromotionType = 'percentage' | 'flat' | 'delivery';
+
+interface PromotionDefinition {
+  type: PromotionType;
+  value: number;
+  minimumSubtotal?: number;
+  description?: string;
+}
+
+export interface AppliedPromotion {
+  code: string;
+  amount: number;
+  type: PromotionType;
+  description?: string;
+}
+
+export interface PromotionResult {
+  appliedPromotion?: AppliedPromotion;
+  reason?: string;
+}
+
+const PROMOTIONS: Record<string, PromotionDefinition> = {
+  WELCOME20: {
+    type: 'percentage',
+    value: 0.2,
+    minimumSubtotal: 20,
+    description: '20% off first order over $20',
+  },
+  FREESHIP: {
+    type: 'delivery',
+    value: 1,
+    minimumSubtotal: 15,
+    description: 'Free delivery on orders over $15',
+  },
+};
+
+const clampDiscount = (amount: number, ceiling: number): number => {
+  if (amount <= 0) {
+    return 0;
+  }
+  if (amount > ceiling) {
+    return ceiling;
+  }
+  return Number(amount.toFixed(2));
+};
+
+export const evaluatePromoCode = (
+  rawCode: string | null | undefined,
+  subtotal: number,
+  deliveryFee: number,
+): PromotionResult => {
+  if (!rawCode) {
+    return {};
+  }
+
+  const normalized = rawCode.trim().toUpperCase();
+  if (!normalized) {
+    return {};
+  }
+
+  const definition = PROMOTIONS[normalized];
+  if (!definition) {
+    return { reason: 'unknown_promo_code' };
+  }
+
+  if (definition.minimumSubtotal && subtotal < definition.minimumSubtotal) {
+    return { reason: 'minimum_not_met' };
+  }
+
+  const ceiling = subtotal + deliveryFee;
+  switch (definition.type) {
+    case 'percentage': {
+      const amount = clampDiscount(subtotal * definition.value, ceiling);
+      if (amount <= 0) {
+        return { reason: 'no_discount' };
+      }
+      return {
+        appliedPromotion: {
+          code: normalized,
+          amount,
+          type: definition.type,
+          description: definition.description,
+        },
+      };
+    }
+    case 'flat': {
+      const amount = clampDiscount(definition.value, ceiling);
+      if (amount <= 0) {
+        return { reason: 'no_discount' };
+      }
+      return {
+        appliedPromotion: {
+          code: normalized,
+          amount,
+          type: definition.type,
+          description: definition.description,
+        },
+      };
+    }
+    case 'delivery': {
+      if (deliveryFee <= 0) {
+        return { reason: 'no_delivery_fee' };
+      }
+      const amount = clampDiscount(deliveryFee * definition.value, ceiling);
+      return {
+        appliedPromotion: {
+          code: normalized,
+          amount,
+          type: definition.type,
+          description: definition.description,
+        },
+      };
+    }
+    default:
+      return {};
+  }
+};
+

--- a/src/app/cart/CartClientPage.tsx
+++ b/src/app/cart/CartClientPage.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { Minus, Plus, Trash2 } from "lucide-react"
@@ -11,26 +12,211 @@ import { Input } from "@/components/ui/input"
 import { MainNav } from "@/components/main-nav"
 import { MobileNav } from "@/components/mobile-nav"
 import { Footer } from "@/components/footer"
-import { LanguageProvider, useLanguage } from "@/contexts/language-context"
-import { calculatePricingBreakdown } from "@/lib/pricing"
-import { sampleCartItems } from "@/lib/sample-cart-items"
+import { AppProviders } from "@/components/app-providers"
+import { CartButton } from "@/components/cart-button"
+import { useCart } from "@/contexts/cart-context"
+import { useLanguage } from "@/contexts/language-context"
+import { formatCurrency as formatMenuCurrency } from "@/lib/menu-data"
 
 function CartContent() {
-  const [cartItems, setCartItems] = useState(sampleCartItems)
+  const { t, language } = useLanguage()
+  const {
+    items,
+    orderMode,
+    setOrderMode,
+    subtotal,
+    deliveryFee,
+    discount,
+    total,
+    removeItem,
+    updateQuantity,
+    clearCart,
+    applyPromoCode,
+    promoCode,
+    isLoading,
+    error,
+    refreshCart,
+  } = useCart()
+  const [promoInput, setPromoInput] = useState(promoCode ?? "")
+  const [isApplyingPromo, setIsApplyingPromo] = useState(false)
+
+  const formatCurrency = (value: number) => formatMenuCurrency(value, language)
+
+  const handleApplyPromo = async () => {
+    setIsApplyingPromo(true)
+    try {
+      await applyPromoCode(promoInput.trim() ? promoInput.trim() : null)
+    } finally {
+      setIsApplyingPromo(false)
+    }
+  }
+
+  if (isLoading && items.length === 0) {
+    return <div className="py-16 text-center text-muted-foreground">Loading cart…</div>
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <div className="py-16 text-center space-y-4">
+        <p className="text-red-600 font-semibold">{t("checkout.failure")}</p>
+        <p className="text-muted-foreground">{error}</p>
+        <Button onClick={() => void refreshCart()} variant="outline" className="rounded-full">
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="py-16 text-center space-y-6">
+        <h2 className="text-2xl font-semibold">{t("cart.empty")}</h2>
+        <p className="text-muted-foreground">{t("cart.emptySubtitle")}</p>
+        <div className="flex justify-center gap-4">
+          <Link href="/menu">
+            <Button className="bg-red-600 hover:bg-red-700 rounded-full">{t("cart.browseMenu")}</Button>
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid md:grid-cols-3 gap-8">
+      <div className="md:col-span-2 space-y-4">
+        {items.map((item) => (
+          <Card key={item.id}>
+            <CardContent className="p-4">
+              <div className="flex items-center gap-4">
+                <div className="relative h-20 w-20 rounded-md overflow-hidden">
+                  <Image src={item.image || "/placeholder.svg"} alt={item.name} fill className="object-cover" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-semibold">{item.name}</h3>
+                  <p className="text-muted-foreground">{formatCurrency(item.price)}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
+                  >
+                    <Minus className="h-4 w-4" />
+                  </Button>
+                  <span className="w-8 text-center">{item.quantity}</span>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => updateQuantity(item.id, item.quantity + 1)}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="text-right min-w-[80px]">
+                  <div className="font-semibold">{formatCurrency(item.price * item.quantity)}</div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-red-500 hover:text-red-700"
+                    onClick={() => removeItem(item.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+        <div className="flex justify-between">
+          <Button variant="ghost" onClick={() => void clearCart()} className="text-red-600 hover:text-red-700">
+            Clear cart
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <Card>
+          <CardContent className="p-6 space-y-4">
+            <h2 className="text-xl font-bold">{t("cart.orderSummary")}</h2>
+
+            <div className="mb-4">
+              <p className="text-sm font-medium text-muted-foreground mb-2">{t("cart.orderModeLabel")}</p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant={orderMode === "delivery" ? "default" : "outline"}
+                  className="flex-1"
+                  onClick={() => setOrderMode("delivery")}
+                >
+                  {t("cart.delivery")}
+                </Button>
+                <Button
+                  type="button"
+                  variant={orderMode === "pickup" ? "default" : "outline"}
+                  className="flex-1"
+                  onClick={() => setOrderMode("pickup")}
+                >
+                  {t("cart.pickup")}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                {orderMode === "delivery" ? t("cart.deliveryDescription") : t("cart.pickupDescription")}
+              </p>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span>{t("cart.subtotal")}</span>
+                <span>{formatCurrency(subtotal)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>{t("cart.deliveryFee")}</span>
+                <span>{formatCurrency(deliveryFee)}</span>
+              </div>
+              {discount > 0 && (
+                <div className="flex justify-between text-green-600">
+                  <span>Discount</span>
+                  <span>-{formatCurrency(discount)}</span>
+                </div>
+              )}
+              <Separator />
+              <div className="flex justify-between font-bold">
+                <span>{t("cart.total")}</span>
+                <span>{formatCurrency(total)}</span>
+              </div>
+            </div>
+
+            <div className="pt-4 space-y-3">
+              <Input
+                placeholder={t("cart.promoCode")}
+                value={promoInput}
+                onChange={(event) => setPromoInput(event.target.value)}
+              />
+              <Button className="w-full" onClick={handleApplyPromo} disabled={isApplyingPromo} variant="outline">
+                {isApplyingPromo ? "Applying…" : "Apply"}
+              </Button>
+              <Link href="/order">
+                <Button className="w-full bg-red-600 hover:bg-red-700">
+                  {t("cart.proceedToCheckout")}
+                </Button>
+              </Link>
+              <Link href="/menu">
+                <Button variant="outline" className="w-full">
+                  {t("cart.continueShopping")}
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function CartPageLayout() {
   const { t } = useLanguage()
-
-  const locale = localeMap[language] ?? "en-US"
-  const currency = currencyMap[language] ?? "USD"
-
-  const handleDecrease = (id: number, quantity: number) => {
-    updateQuantity(id, quantity - 1)
-  }
-
-  const handleIncrease = (id: number, quantity: number) => {
-    updateQuantity(id, quantity + 1)
-  }
-
-  const pricing = calculatePricingBreakdown(cartItems)
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -55,131 +241,7 @@ function CartContent() {
       <main className="flex-1">
         <div className="container py-8">
           <h1 className="text-3xl font-bold mb-8">{t("cart.title")}</h1>
-
-eeeeeeeeeeeeeee          {items.length === 0 ? (
-            <div className="text-center py-12">
-              <h2 className="text-2xl font-semibold mb-4">{t("cart.empty")}</h2>
-              <p className="text-muted-foreground mb-6">{t("cart.emptySubtitle")}</p>
-              <Link href="/menu">
-                <Button className="bg-red-600 hover:bg-red-700">{t("cart.browseMenu")}</Button>
-              </Link>
-            </div>
-          ) : (
-            <div className="grid md:grid-cols-3 gap-8">
-              <div className="md:col-span-2 space-y-4">
-                {items.map((item) => (
-                  <Card key={item.id}>
-                    <CardContent className="p-4">
-                      <div className="flex items-center gap-4">
-                        <div className="relative h-20 w-20 rounded-md overflow-hidden">
-                          <Image src={item.image || "/placeholder.svg"} alt={item.name} fill className="object-cover" />
-                        </div>
-                        <div className="flex-1">
-                          <h3 className="font-semibold">{item.name}</h3>
-                          <p className="text-muted-foreground">{formatCurrency(item.price, locale, currency)}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() => handleDecrease(item.id, item.quantity)}
-                          >
-                            <Minus className="h-4 w-4" />
-                          </Button>
-                          <span className="w-8 text-center">{item.quantity}</span>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() => handleIncrease(item.id, item.quantity)}
-                          >
-                            <Plus className="h-4 w-4" />
-                          </Button>
-                        </div>
-                        <div className="text-right min-w-[80px]">
-                          <div className="font-semibold">{formatCurrency(item.price * item.quantity, locale, currency)}</div>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 text-red-500 hover:text-red-700"
-                            onClick={() => removeItem(item.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  )
-                })}
-              </div>
-
-              <div>
-                <Card>
-                  <CardContent className="p-6">
-                    <h2 className="text-xl font-bold mb-4">{t("cart.orderSummary")}</h2>
-                    <div className="mb-6">
-                      <p className="text-sm font-medium text-muted-foreground mb-2">{t("cart.orderModeLabel")}</p>
-                      <div className="flex gap-2">
-                        <Button
-                          type="button"
-                          variant={orderMode === "delivery" ? "default" : "outline"}
-                          className="flex-1"
-                          onClick={() => setOrderMode("delivery")}
-                        >
-                          {t("cart.delivery")}
-                        </Button>
-                        <Button
-                          type="button"
-                          variant={orderMode === "pickup" ? "default" : "outline"}
-                          className="flex-1"
-                          onClick={() => setOrderMode("pickup")}
-                        >
-                          {t("cart.pickup")}
-                        </Button>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-2">
-                        {orderMode === "delivery" ? t("cart.deliveryDescription") : t("cart.pickupDescription")}
-                      </p>
-                    </div>
-                    <div className="space-y-4">
-                      <div className="flex justify-between">
-                        <span>{t("cart.subtotal")}</span>
-                        <span>${pricing.subtotal.toFixed(2)}</span>
-                      </div>
-                      <div className="flex justify-between">
-                        <span>{t("cart.deliveryFee")}</span>
-                        <span>${pricing.deliveryFee.toFixed(2)}</span>
-                      </div>
-                      <div className="flex justify-between">
-                        <span>{t("cart.tax")}</span>
-                        <span>${pricing.tax.toFixed(2)}</span>
-                      </div>
-                      <Separator />
-                      <div className="flex justify-between font-bold">
-                        <span>{t("cart.total")}</span>
-                        <span>${pricing.total.toFixed(2)}</span>
-                      </div>
-
-                      <div className="pt-4">
-                        <Input placeholder={t("cart.promoCode")} className="mb-4" />
-                        <Link href="/order">
-                          <Button className="w-full bg-red-600 hover:bg-red-700 mb-2">
-                            {t("cart.proceedToCheckout")}
-                          </Button>
-                        </Link>
-                        <Link href="/menu">
-                          <Button variant="outline" className="w-full">
-                            {t("cart.continueShopping")}
-                          </Button>
-                        </Link>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </div>
-            </div>
-          )}
+          <CartContent />
         </div>
       </main>
       <Footer />
@@ -190,7 +252,8 @@ eeeeeeeeeeeeeee          {items.length === 0 ? (
 export default function CartPageClient() {
   return (
     <AppProviders>
-      <CartContent />
+      <CartPageLayout />
     </AppProviders>
   )
 }
+

--- a/src/components/category-section.tsx
+++ b/src/components/category-section.tsx
@@ -15,6 +15,15 @@ import {
 export function CategorySection() {
   const { t } = useLanguage()
 
+  type CategoryCard = {
+    id: string
+    name: string
+    image: string
+    count: number
+    href: string
+    featured?: boolean
+  }
+
   const coreCategories: Array<{ key: MenuCategory; featured?: boolean }> = [
     { key: "pizzas", featured: true },
     { key: "kebabs", featured: true },
@@ -22,7 +31,7 @@ export function CategorySection() {
     { key: "sides" },
   ]
 
-  const categories = [
+  const categories: CategoryCard[] = [
     ...coreCategories.map(({ key, featured }) => ({
       id: key,
       name: t(getMenuCategoryLabelKey(key)),

--- a/src/components/food-card.tsx
+++ b/src/components/food-card.tsx
@@ -43,10 +43,26 @@ export function FoodCard({ item }: FoodCardProps) {
     ? formatCurrency(item.price, language)
     : undefined
 
-  const handleAddToCart = () => {
-    addItem(item.id, 1)
+  const handleAddToCart = async () => {
+    if (isAdding) {
+      return
+    }
     setIsAdding(true)
-    setTimeout(() => setIsAdding(false), 1000)
+    try {
+      await addItem(
+        {
+          id: item.id,
+          name: item.name,
+          price: Number(discountedPrice.toFixed(2)),
+          image: item.image,
+        },
+        1,
+      )
+      setTimeout(() => setIsAdding(false), 1000)
+    } catch (error) {
+      console.error("Failed to add item to cart", error)
+      setIsAdding(false)
+    }
   }
 
   return (

--- a/src/contexts/cart-context.tsx
+++ b/src/contexts/cart-context.tsx
@@ -1,87 +1,352 @@
 "use client"
 
-import { createContext, useContext, useMemo, useState, useCallback, type ReactNode } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
 
 import {
-  type CartItem,
-  type OrderMode,
-  calculateItemCount,
-  calculateTotals,
-} from "@/lib/cart"
+  createOrGetCart,
+  updateCart,
+  getCart,
+  submitOrder,
+  type CartApi,
+  type CartLineItem,
+  type CartResponse,
+} from "@/lib/api/cart"
+import { type CartItem, type OrderMode, DEFAULT_DELIVERY_FEE } from "@/lib/cart"
+import { useLanguage } from "./language-context"
+import type { TranslationKey } from "@/lib/translations"
 
 interface CartContextValue {
+  cartId: string | null
   items: CartItem[]
   orderMode: OrderMode
   itemCount: number
+  totalItems: number
   subtotal: number
   deliveryFee: number
+  discount: number
   total: number
-  addItem: (item: Omit<CartItem, "quantity">, quantity?: number) => void
-  removeItem: (id: number) => void
-  updateQuantity: (id: number, quantity: number) => void
-  clearCart: () => void
+  promoCode: string | null
+  isLoading: boolean
+  error: string | null
+  addItem: (item: Omit<CartItem, "quantity">, quantity?: number) => Promise<void>
+  removeItem: (id: number) => Promise<void>
+  updateQuantity: (id: number, quantity: number) => Promise<void>
+  clearCart: () => Promise<void>
   setOrderMode: (mode: OrderMode) => void
+  applyPromoCode: (code: string | null) => Promise<void>
+  refreshCart: () => Promise<void>
+  submitCurrentOrder: (
+    params?: { notes?: string; customer?: { name?: string; phone?: string; email?: string } },
+  ) => Promise<void>
 }
 
 const CartContext = createContext<CartContextValue | undefined>(undefined)
 
+const CART_SESSION_STORAGE_KEY = "pizzakebab.cartSessionId"
+
+const generateSessionId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return Math.random().toString(36).slice(2)
+}
+
+const ensureSessionId = (): string => {
+  if (typeof window === "undefined") {
+    return generateSessionId()
+  }
+  const existing = window.localStorage.getItem(CART_SESSION_STORAGE_KEY)
+  if (existing) {
+    return existing
+  }
+  const newId = generateSessionId()
+  window.localStorage.setItem(CART_SESSION_STORAGE_KEY, newId)
+  return newId
+}
+
+const parseMenuItemId = (raw: string): number => {
+  const parsed = Number.parseInt(raw, 10)
+  if (Number.isFinite(parsed)) {
+    return parsed
+  }
+
+  // create a stable numeric hash for non-numeric ids
+  return Array.from(raw).reduce((acc, char) => acc + char.charCodeAt(0), 0)
+}
+
+type TranslateFn = (key: TranslationKey) => string
+
+const toDisplayItems = (lines: CartLineItem[], translate: TranslateFn): CartItem[] =>
+  lines
+    .filter((line) => line.quantity > 0)
+    .map((line) => {
+      const menuItem = line.menuItem
+      const fallbackName = menuItem?.name ?? `Item ${line.menuItemId}`
+      const name = menuItem?.nameKey ? translate(menuItem.nameKey) : fallbackName
+      const image = menuItem?.imageUrl
+      const price = menuItem?.price ?? 0
+      const id = parseMenuItemId(menuItem?.id ?? line.menuItemId)
+
+      return {
+        id,
+        name,
+        price,
+        quantity: line.quantity,
+        image,
+      }
+    })
+
+const sumQuantities = (items: CartItem[]): number => items.reduce((total, item) => total + item.quantity, 0)
+
+const toCartUpdateItems = (lines: CartLineItem[]): UpdatePayloadItem[] =>
+  lines.map((line) => ({
+    menuItemId: line.menuItemId,
+    quantity: line.quantity,
+    notes: line.notes,
+  }))
+
+interface UpdatePayloadItem {
+  menuItemId: string
+  quantity: number
+  notes?: string
+}
+
+const mergeLineItems = (current: CartLineItem[], updates: Map<string, number>): CartLineItem[] => {
+  const mergedMap = new Map<string, CartLineItem>()
+
+  for (const line of current) {
+    mergedMap.set(line.menuItemId, { ...line })
+  }
+
+  for (const [menuItemId, quantity] of updates.entries()) {
+    const existing = mergedMap.get(menuItemId)
+    if (quantity <= 0) {
+      mergedMap.delete(menuItemId)
+      continue
+    }
+
+    mergedMap.set(menuItemId, {
+      menuItemId,
+      quantity,
+      notes: existing?.notes,
+      menuItem: existing?.menuItem,
+    })
+  }
+
+  return Array.from(mergedMap.values())
+}
+
 export function CartProvider({ children }: { children: ReactNode }) {
-  const [items, setItems] = useState<CartItem[]>([])
+  const { t } = useLanguage()
+  const [cart, setCart] = useState<CartApi | null>(null)
   const [orderMode, setOrderMode] = useState<OrderMode>("delivery")
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const sessionIdRef = useRef<string | null>(null)
 
-  const addItem = useCallback((item: Omit<CartItem, "quantity">, quantity = 1) => {
-    setItems((prevItems) => {
-      const existingItemIndex = prevItems.findIndex((cartItem) => cartItem.id === item.id)
+  const initializeCart = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      if (!sessionIdRef.current) {
+        sessionIdRef.current = ensureSessionId()
+      }
+      const response = await createOrGetCart({ sessionId: sessionIdRef.current })
+      setCart(response.cart)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load cart")
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
 
-      if (existingItemIndex > -1) {
-        const updatedItems = [...prevItems]
-        updatedItems[existingItemIndex] = {
-          ...updatedItems[existingItemIndex],
-          quantity: updatedItems[existingItemIndex].quantity + quantity,
+  useEffect(() => {
+    void initializeCart()
+  }, [initializeCart])
+
+  const syncCart = useCallback(async (operation: () => Promise<CartResponse | void>) => {
+    setIsLoading(true)
+    try {
+      const result = await operation()
+      if (result && "cart" in result) {
+        setCart(result.cart)
+      } else if (cart?.id) {
+        const refreshed = await getCart(cart.id)
+        setCart(refreshed.cart)
+      }
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update cart")
+      throw err
+    } finally {
+      setIsLoading(false)
+    }
+  }, [cart?.id])
+
+  const updateCartItems = useCallback(
+    async (updater: (current: CartLineItem[]) => CartLineItem[]) => {
+      if (!cart?.id) {
+        return
+      }
+      await syncCart(async () => {
+        const nextItems = updater(cart.items)
+        return updateCart(cart.id, { items: toCartUpdateItems(nextItems) })
+      })
+    },
+    [cart, syncCart],
+  )
+
+  const addItem = useCallback<Required<CartContextValue>["addItem"]>(
+    async (item, quantity = 1) => {
+      const menuItemId = String(item.id)
+      const updates = new Map<string, number>()
+      updates.set(menuItemId, (cart?.items.find((line) => line.menuItemId === menuItemId)?.quantity ?? 0) + quantity)
+
+      await updateCartItems((current) => mergeLineItems(current, updates))
+    },
+    [cart?.items, updateCartItems],
+  )
+
+  const removeItem = useCallback<Required<CartContextValue>["removeItem"]>(
+    async (id) => {
+      const menuItemId = String(id)
+      const updates = new Map<string, number>()
+      updates.set(menuItemId, 0)
+
+      await updateCartItems((current) => mergeLineItems(current, updates))
+    },
+    [updateCartItems],
+  )
+
+  const updateQuantity = useCallback<Required<CartContextValue>["updateQuantity"]>(
+    async (id, quantity) => {
+      const menuItemId = String(id)
+      const updates = new Map<string, number>()
+      updates.set(menuItemId, quantity)
+
+      await updateCartItems((current) => mergeLineItems(current, updates))
+    },
+    [updateCartItems],
+  )
+
+  const clearCart = useCallback(async () => {
+    if (!cart?.id) {
+      return
+    }
+    await syncCart(() => updateCart(cart.id, { items: [] }))
+  }, [cart?.id, syncCart])
+
+  const applyPromoCode = useCallback<Required<CartContextValue>["applyPromoCode"]>(
+    async (code) => {
+      if (!cart?.id) {
+        return
+      }
+      await syncCart(() => updateCart(cart.id, { promoCode: code }))
+    },
+    [cart?.id, syncCart],
+  )
+
+  const refreshCart = useCallback(async () => {
+    if (!cart?.id) {
+      await initializeCart()
+      return
+    }
+    setIsLoading(true)
+    try {
+      const refreshed = await getCart(cart.id)
+      setCart(refreshed.cart)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to refresh cart")
+    } finally {
+      setIsLoading(false)
+    }
+  }, [cart?.id, initializeCart])
+
+  const submitCurrentOrder = useCallback<Required<CartContextValue>["submitCurrentOrder"]>(
+    async (params) => {
+      if (!cart?.id) {
+        return
+      }
+      await syncCart(async () => {
+        await submitOrder({
+          cartId: cart.id,
+          promoCode: cart.promoCode,
+          notes: params?.notes,
+          customer: params?.customer,
+        })
+        setCart(null)
+        sessionIdRef.current = null
+        if (typeof window !== "undefined") {
+          window.localStorage.removeItem(CART_SESSION_STORAGE_KEY)
         }
-        return updatedItems
-      }
+        return createOrGetCart({ sessionId: ensureSessionId() })
+      })
+    },
+    [cart, syncCart],
+  )
 
-      return [...prevItems, { ...item, quantity }]
-    })
-  }, [])
+  const displayItems = useMemo(() => toDisplayItems(cart?.items ?? [], t), [cart?.items, t])
+  const itemCount = useMemo(() => sumQuantities(displayItems), [displayItems])
 
-  const removeItem = useCallback((id: number) => {
-    setItems((prevItems) => prevItems.filter((item) => item.id !== id))
-  }, [])
+  const baseSubtotal = cart?.totals.subtotal ?? 0
+  const baseDeliveryFee = cart?.totals.deliveryFee ?? DEFAULT_DELIVERY_FEE
+  const discount = cart?.totals.discount ?? 0
+  const appliedDeliveryFee = orderMode === "pickup" ? 0 : baseDeliveryFee
+  const total = Math.max(baseSubtotal - discount + appliedDeliveryFee, 0)
 
-  const updateQuantity = useCallback((id: number, quantity: number) => {
-    setItems((prevItems) => {
-      if (quantity <= 0) {
-        return prevItems.filter((item) => item.id !== id)
-      }
-
-      return prevItems.map((item) => (item.id === id ? { ...item, quantity } : item))
-    })
-  }, [])
-
-  const clearCart = useCallback(() => {
-    setItems([])
-  }, [])
-
-  const totals = useMemo(() => calculateTotals(items, orderMode), [items, orderMode])
-  const itemCount = useMemo(() => calculateItemCount(items), [items])
-
-  const value = useMemo(
+  const value = useMemo<CartContextValue>(
     () => ({
-      items,
+      cartId: cart?.id ?? null,
+      items: displayItems,
       orderMode,
       itemCount,
-      subtotal: totals.subtotal,
-      deliveryFee: totals.deliveryFee,
-      total: totals.total,
+      totalItems: itemCount,
+      subtotal: baseSubtotal,
+      deliveryFee: appliedDeliveryFee,
+      discount,
+      total,
+      promoCode: cart?.promoCode ?? null,
+      isLoading,
+      error,
       addItem,
       removeItem,
       updateQuantity,
       clearCart,
       setOrderMode,
+      applyPromoCode,
+      refreshCart,
+      submitCurrentOrder,
     }),
-    [items, orderMode, itemCount, totals, addItem, removeItem, updateQuantity, clearCart, setOrderMode],
+    [
+      cart?.id,
+      cart?.promoCode,
+      displayItems,
+      orderMode,
+      itemCount,
+      baseSubtotal,
+      appliedDeliveryFee,
+      discount,
+      total,
+      isLoading,
+      error,
+      addItem,
+      removeItem,
+      updateQuantity,
+      clearCart,
+      applyPromoCode,
+      refreshCart,
+      submitCurrentOrder,
+    ],
   )
 
   return <CartContext.Provider value={value}>{children}</CartContext.Provider>
@@ -89,10 +354,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
 export function useCart() {
   const context = useContext(CartContext)
-
   if (!context) {
     throw new Error("useCart must be used within a CartProvider")
   }
-
   return context
 }
+

--- a/src/lib/address.ts
+++ b/src/lib/address.ts
@@ -1,3 +1,5 @@
+import type { TranslationKey } from "@/lib/translations"
+
 export interface AddressFields {
   address: string
   city: string
@@ -7,7 +9,9 @@ export interface AddressFields {
 export type AddressFieldKey = keyof AddressFields
 export type AddressErrors = Partial<Record<AddressFieldKey, string>>
 
-export function getAddressLabels(t: (key: string) => string) {
+type TranslateFn = (key: TranslationKey) => string
+
+export function getAddressLabels(t: TranslateFn) {
   return {
     address: t("address.labels.street"),
     city: t("address.labels.city"),
@@ -15,7 +19,7 @@ export function getAddressLabels(t: (key: string) => string) {
   }
 }
 
-export function validateAddressFields(fields: AddressFields, t: (key: string) => string): AddressErrors {
+export function validateAddressFields(fields: AddressFields, t: TranslateFn): AddressErrors {
   const errors: AddressErrors = {}
 
   if (!fields.address.trim()) {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,75 @@
+const DEFAULT_API_BASE_URL = "http://localhost:4000"
+const DEFAULT_TENANT_ID = "pizzakebab"
+
+const resolveBaseUrl = (): string => {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_API_BASE_URL) {
+    return process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, "")
+  }
+  if (typeof window !== "undefined") {
+    const fromGlobal = (window as typeof window & { __API_BASE_URL__?: string }).__API_BASE_URL__
+    if (fromGlobal) {
+      return fromGlobal.replace(/\/$/, "")
+    }
+  }
+  return DEFAULT_API_BASE_URL
+}
+
+const resolveTenantId = (): string => {
+  if (typeof process !== "undefined" && process.env.NEXT_PUBLIC_TENANT_ID) {
+    return process.env.NEXT_PUBLIC_TENANT_ID
+  }
+  return DEFAULT_TENANT_ID
+}
+
+const buildUrl = (baseUrl: string, path: string): string => {
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    return path
+  }
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`
+}
+
+export class ApiError extends Error {
+  public readonly status: number
+  public readonly detail?: string
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message)
+    this.status = status
+    this.detail = detail
+  }
+}
+
+export async function apiFetch<TResponse>(
+  path: string,
+  init: RequestInit = {},
+): Promise<TResponse> {
+  const baseUrl = resolveBaseUrl()
+  const tenantId = resolveTenantId()
+
+  const headers = new Headers(init.headers ?? {})
+  if (!headers.has("accept")) {
+    headers.set("accept", "application/json")
+  }
+  if (init.body && !headers.has("content-type")) {
+    headers.set("content-type", "application/json")
+  }
+  headers.set("x-tenant-id", tenantId)
+
+  const response = await fetch(buildUrl(baseUrl, path), {
+    ...init,
+    headers,
+    cache: init.cache ?? "no-store",
+  })
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => undefined)
+    throw new ApiError(`Request to ${path} failed with status ${response.status}`, response.status, detail)
+  }
+
+  if (response.status === 204) {
+    return undefined as TResponse
+  }
+
+  return (await response.json()) as TResponse
+}
+

--- a/src/lib/api/cart.ts
+++ b/src/lib/api/cart.ts
@@ -1,0 +1,118 @@
+import { apiFetch } from "@/lib/api-client"
+import type { TranslationKey } from "@/lib/translations"
+
+export interface CartMenuItem {
+  id: string
+  menuId: string
+  name: string
+  nameKey?: TranslationKey
+  description?: string
+  descriptionKey?: TranslationKey
+  categoryKey?: TranslationKey
+  price: number
+  currency: string
+  imageUrl?: string
+  rating?: number
+  discountPercentage?: number
+  isPopular?: boolean
+  isNew?: boolean
+  isAvailable: boolean
+}
+
+export interface CartLineItem {
+  menuItemId: string
+  quantity: number
+  notes?: string
+  menuItem?: CartMenuItem | null
+}
+
+export interface CartTotals {
+  subtotal: number
+  deliveryFee: number
+  discount: number
+  total: number
+  currency: string
+}
+
+export interface AppliedPromotion {
+  code: string
+  amount: number
+  type: string
+  description?: string
+}
+
+export interface CartApi {
+  id: string
+  deviceId: string
+  sessionId?: string | null
+  userId?: string | null
+  status: "open" | "checked_out"
+  promoCode?: string | null
+  createdAt: string
+  updatedAt: string
+  items: CartLineItem[]
+  totals: CartTotals
+  promotion?: AppliedPromotion | null
+}
+
+export interface CartResponse {
+  cart: CartApi
+}
+
+export interface CreateCartPayload {
+  deviceId?: string
+  sessionId?: string
+  userId?: string
+  promoCode?: string
+}
+
+export interface UpdateCartPayload {
+  items?: Array<{ menuItemId: string; quantity: number; notes?: string }>
+  promoCode?: string | null
+}
+
+export const createOrGetCart = (payload: CreateCartPayload): Promise<CartResponse> =>
+  apiFetch<CartResponse>("/carts", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  })
+
+export const getCart = (cartId: string): Promise<CartResponse> =>
+  apiFetch<CartResponse>(`/carts/${cartId}`)
+
+export const updateCart = (cartId: string, payload: UpdateCartPayload): Promise<CartResponse> =>
+  apiFetch<CartResponse>(`/carts/${cartId}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  })
+
+export interface SubmitOrderPayload {
+  cartId: string
+  promoCode?: string | null
+  notes?: string
+  customer?: {
+    name?: string
+    phone?: string
+    email?: string
+  }
+}
+
+export interface OrderResponse {
+  order: {
+    id: string
+    cartId: string
+    status: string
+    total: number
+    currency: string
+    submittedAt: string
+    promotion?: AppliedPromotion | null
+    totals: CartTotals
+  }
+}
+
+export const submitOrder = (payload: SubmitOrderPayload): Promise<OrderResponse> =>
+  apiFetch<OrderResponse>("/orders", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  })
+

--- a/src/lib/api/menu.ts
+++ b/src/lib/api/menu.ts
@@ -1,0 +1,37 @@
+import { apiFetch } from "@/lib/api-client"
+import type { TranslationKey } from "@/lib/translations"
+
+export interface MenuItemApi {
+  id: string
+  legacyId?: number
+  menuId: string
+  name: string
+  description?: string
+  nameKey?: TranslationKey
+  descriptionKey?: TranslationKey
+  categoryKey?: TranslationKey
+  price: number
+  currency: string
+  imageUrl?: string
+  rating?: number
+  discountPercentage?: number
+  isPopular?: boolean
+  isNew?: boolean
+  isAvailable: boolean
+}
+
+export interface MenuApi {
+  id: string
+  name: string
+  description?: string
+  translationKey?: TranslationKey
+  isActive: boolean
+  items: MenuItemApi[]
+}
+
+export interface MenusResponse {
+  menus: MenuApi[]
+}
+
+export const fetchMenus = async (): Promise<MenusResponse> => apiFetch<MenusResponse>("/menus")
+

--- a/src/lib/menu-transform.ts
+++ b/src/lib/menu-transform.ts
@@ -1,0 +1,77 @@
+import type { MenuApi, MenuItemApi } from "@/lib/api/menu"
+import type { LocalizedMenuItem } from "@/lib/menu-data"
+import type { TranslationKey } from "@/lib/translations"
+
+export const CATEGORY_ORDER = ["pizzas", "kebabs", "wraps", "sides", "drinks", "desserts"] as const
+export type OrderedCategory = (typeof CATEGORY_ORDER)[number]
+
+const FALLBACK_IMAGE = "/placeholder.svg?height=300&width=300"
+
+export const toNumericId = (value: string): number => {
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isFinite(parsed)) {
+    return parsed
+  }
+  return Array.from(value).reduce((acc, char) => acc + char.charCodeAt(0), 0)
+}
+
+type TranslateFn = (key: TranslationKey) => string
+
+export const toLocalizedItem = (
+  item: MenuItemApi,
+  categoryLabel: string,
+  translate: TranslateFn,
+): LocalizedMenuItem => {
+  const name = item.nameKey ? translate(item.nameKey) : item.name
+  const description = item.descriptionKey ? translate(item.descriptionKey) : item.description ?? ""
+  const category = item.categoryKey ? translate(item.categoryKey) : categoryLabel
+
+  return {
+    id: toNumericId(item.id),
+    name,
+    description,
+    price: item.price,
+    image: item.imageUrl ?? FALLBACK_IMAGE,
+    category,
+    rating: item.rating,
+    popular: item.isPopular,
+    discount: item.discountPercentage ?? undefined,
+    new: item.isNew,
+  }
+}
+
+export const buildCategoryMap = (
+  menus: MenuApi[],
+  translate: TranslateFn,
+): Record<string, LocalizedMenuItem[]> => {
+  const baseEntries: Array<[string, LocalizedMenuItem[]]> = CATEGORY_ORDER.map((category) => [
+    category,
+    [] as LocalizedMenuItem[],
+  ])
+  const knownCategories = new Set(baseEntries.map(([category]) => category))
+
+  for (const menu of menus) {
+    if (!knownCategories.has(menu.id)) {
+      baseEntries.push([menu.id, []])
+      knownCategories.add(menu.id)
+    }
+  }
+
+  const categoryMap = new Map<string, LocalizedMenuItem[]>(baseEntries)
+
+  for (const menu of menus) {
+    const label = menu.translationKey ? translate(menu.translationKey) : menu.name
+    const items = menu.items
+      .filter((item) => item.isAvailable)
+      .map((item) => toLocalizedItem(item, label, translate))
+
+    const existing = categoryMap.get(menu.id) ?? []
+    categoryMap.set(menu.id, [...existing, ...items])
+  }
+
+  return Object.fromEntries(categoryMap.entries()) as Record<string, LocalizedMenuItem[]>
+}
+
+export const isKnownCategory = (value: string): value is OrderedCategory =>
+  (CATEGORY_ORDER as readonly string[]).includes(value)
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "services/api/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- wire up Fastify to expose /menus, /carts, and /orders with JSON schemas, tenant seeding, and kitchen queue hand-off
- add shared API client helpers plus menu/cart bindings so Next.js pages and cart context read and persist via the backend
- repair the interactive menu card/button flows and tighten cart helpers for translation-aware display data

## Testing
- npm run type-check
- npm run api:build *(fails: missing fastify/mongodb type resolution and implicit any annotations in services/api)*

------
https://chatgpt.com/codex/tasks/task_e_68f80df349fc832f91a48b2d3a44dc94