### PR TITLE
Apply shared UI components across admin console

### DIFF
--- a/app/admin/devices/page.tsx
+++ b/app/admin/devices/page.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AdminApiError, AdminDevice, adminApi } from '@/lib/admin-api';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+
+const DEVICE_TYPES: Array<AdminDevice['type']> = ['kiosk', 'tablet', 'mobile'];
+
+const formatLastSeen = (value?: string | null) => {
+  if (!value) {
+    return 'Never';
+  }
+  return new Date(value).toLocaleString();
+};
+
+export default function AdminDevicesPage() {
+  const [devices, setDevices] = useState<AdminDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newDevice, setNewDevice] = useState<Pick<AdminDevice, 'label' | 'type'>>({ label: '', type: 'kiosk' });
+  const [savingDeviceId, setSavingDeviceId] = useState<string | null>(null);
+
+  const loadDevices = async () => {
+    setLoading(true);
+    try {
+      const result = await adminApi.devices();
+      setDevices(result);
+      setError(null);
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setError('Unable to load devices');
+      } else {
+        setError('Unexpected error fetching devices');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDevices();
+  }, []);
+
+  const handleRegisterDevice = async () => {
+    if (!newDevice.label.trim()) {
+      setError('Device label is required');
+      return;
+    }
+    setSavingDeviceId('new');
+    try {
+      const created = await adminApi.saveDevice(newDevice);
+      if (created) {
+        setDevices((prev) => [created, ...prev]);
+        setNewDevice({ label: '', type: 'kiosk' });
+      } else {
+        await loadDevices();
+      }
+    } catch (err) {
+      setError('Failed to register device');
+    } finally {
+      setSavingDeviceId(null);
+    }
+  };
+
+  const handleUpdateDevice = async (device: AdminDevice) => {
+    setSavingDeviceId(device.id);
+    try {
+      const updated = await adminApi.saveDevice(device);
+      if (updated) {
+        setDevices((prev) => prev.map((entry) => (entry.id === device.id ? updated : entry)));
+      }
+    } catch (err) {
+      setError('Failed to update device');
+    } finally {
+      setSavingDeviceId(null);
+    }
+  };
+
+  const handlePingDevice = async (deviceId: string) => {
+    try {
+      const updated = await adminApi.pingDevice(deviceId);
+      if (updated) {
+        setDevices((prev) => prev.map((entry) => (entry.id === deviceId ? updated : entry)));
+      }
+    } catch (err) {
+      setError('Failed to ping device');
+    }
+  };
+
+  const handleDeleteDevice = async (deviceId: string) => {
+    try {
+      await adminApi.deleteDevice(deviceId);
+      setDevices((prev) => prev.filter((entry) => entry.id !== deviceId));
+    } catch (err) {
+      setError('Failed to remove device');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-100">Device management</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          Register kiosks, tablets, and other devices that connect to the admin APIs.
+        </p>
+      </div>
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader>
+          <CardTitle className="text-lg text-slate-100">Register new device</CardTitle>
+          <CardDescription className="text-slate-400">
+            Provide a label and select the type to register a new device with your tenant.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-2 text-sm text-slate-300">
+            <Label htmlFor="new-device-label" className="text-slate-300">
+              Label
+            </Label>
+            <Input
+              id="new-device-label"
+              value={newDevice.label}
+              onChange={(event) => setNewDevice((prev) => ({ ...prev, label: event.target.value }))}
+              placeholder="Front counter kiosk"
+            />
+          </div>
+          <div className="space-y-2 text-sm text-slate-300">
+            <Label htmlFor="new-device-type" className="text-slate-300">
+              Device type
+            </Label>
+            <Select
+              id="new-device-type"
+              value={newDevice.type}
+              onChange={(event) => setNewDevice((prev) => ({ ...prev, type: event.target.value as AdminDevice['type'] }))}
+            >
+              {DEVICE_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type.charAt(0).toUpperCase() + type.slice(1)}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className="flex items-end">
+            <Button type="button" className="w-full" onClick={handleRegisterDevice} disabled={savingDeviceId === 'new'}>
+              {savingDeviceId === 'new' ? 'Registering…' : 'Register device'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="text-lg text-slate-100">Registered devices</CardTitle>
+            <CardDescription className="text-slate-400">
+              Manage device labels, types, and track their last check-in time.
+            </CardDescription>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={loadDevices}>
+            Refresh
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-slate-300">Loading devices…</p>
+          ) : devices.length === 0 ? (
+            <p className="text-sm text-slate-400">No devices registered yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {devices.map((device) => {
+                const savingCurrentDevice = savingDeviceId === device.id;
+
+                return (
+                  <Card key={device.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                    <CardContent className="grid gap-3 p-4 text-sm md:grid-cols-4">
+                      <div className="space-y-2">
+                        <Label htmlFor={`device-${device.id}-label`} className="text-slate-300">
+                          Label
+                        </Label>
+                        <Input
+                          id={`device-${device.id}-label`}
+                          value={device.label}
+                          onChange={(event) =>
+                            setDevices((prev) =>
+                              prev.map((entry) =>
+                                entry.id === device.id ? { ...entry, label: event.target.value } : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`device-${device.id}-type`} className="text-slate-300">
+                          Type
+                        </Label>
+                        <Select
+                          id={`device-${device.id}-type`}
+                          value={device.type}
+                          onChange={(event) =>
+                            setDevices((prev) =>
+                              prev.map((entry) =>
+                                entry.id === device.id
+                                  ? { ...entry, type: event.target.value as AdminDevice['type'] }
+                                  : entry,
+                              ),
+                            )
+                          }
+                        >
+                          {DEVICE_TYPES.map((type) => (
+                            <option key={type} value={type}>
+                              {type.charAt(0).toUpperCase() + type.slice(1)}
+                            </option>
+                          ))}
+                        </Select>
+                      </div>
+                      <div className="space-y-2 text-slate-300">
+                        <Label className="text-slate-300" htmlFor={`device-${device.id}-last-seen`}>
+                          Last seen
+                        </Label>
+                        <p
+                          id={`device-${device.id}-last-seen`}
+                          className="rounded-md border border-slate-800 bg-slate-950 px-3 py-2 text-xs text-slate-400"
+                        >
+                          {formatLastSeen(device.lastSeenAt)}
+                        </p>
+                      </div>
+                      <div className="flex items-center justify-end gap-2">
+                        <Button type="button" variant="outline" size="sm" onClick={() => handlePingDevice(device.id)}>
+                          Ping
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="border-red-900/40 text-red-300 hover:bg-red-900/20"
+                          onClick={() => handleDeleteDevice(device.id)}
+                        >
+                          Remove
+                        </Button>
+                        <Button type="button" size="sm" onClick={() => handleUpdateDevice(device)} disabled={savingCurrentDevice}>
+                          {savingCurrentDevice ? 'Saving…' : 'Save'}
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import { AdminLayoutClient } from '@/components/admin/AdminLayoutClient';
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <AdminLayoutClient>{children}</AdminLayoutClient>;
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AdminApiError, adminApi } from '@/lib/admin-api';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('pizzakebab-admin@example.com');
+  const [password, setPassword] = useState('changeme');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await adminApi.login(email, password);
+      router.replace('/admin');
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setError('Invalid email or password');
+      } else {
+        setError('Unable to sign in. Please try again.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-4 text-slate-100">
+      <Card className="w-full max-w-md border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader>
+          <CardTitle className="text-2xl text-slate-50">Admin console</CardTitle>
+          <CardDescription className="text-slate-400">
+            Sign in with your tenant credentials to manage the restaurant.
+          </CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-slate-300">
+                Email
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-slate-300">
+                Password
+              </Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </div>
+            {error ? <p className="text-sm text-red-400">{error}</p> : null}
+          </CardContent>
+          <CardFooter>
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/menus/page.tsx
+++ b/app/admin/menus/page.tsx
@@ -1,0 +1,756 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { adminApi, AdminApiError, AdminMenu, AdminMenuItem, AdminOperatingHour, AdminPricingOverride } from '@/lib/admin-api';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+
+const emptyMenu = (id: string): AdminMenu => ({
+  id,
+  name: '',
+  description: '',
+  translationKey: '',
+  isActive: true,
+  items: [],
+});
+
+const emptyMenuItem = (id: string): AdminMenuItem => ({
+  id,
+  name: '',
+  description: '',
+  categoryKey: '',
+  price: 0,
+  currency: 'USD',
+  isAvailable: true,
+  imageUrl: '',
+  isPopular: false,
+  isNew: false,
+});
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export default function AdminMenusPage() {
+  const [menus, setMenus] = useState<AdminMenu[]>([]);
+  const [pricingOverrides, setPricingOverrides] = useState<AdminPricingOverride[]>([]);
+  const [operatingHours, setOperatingHours] = useState<AdminOperatingHour[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [savingMenuId, setSavingMenuId] = useState<string | null>(null);
+  const [savingOverrideId, setSavingOverrideId] = useState<string | null>(null);
+  const [savingHourId, setSavingHourId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [menuData, overrideData, hourData] = await Promise.all([
+          adminApi.menus(),
+          adminApi.pricingOverrides(),
+          adminApi.operatingHours(),
+        ]);
+        setMenus(menuData);
+        setPricingOverrides(overrideData);
+        setOperatingHours(hourData);
+        setError(null);
+      } catch (err) {
+        if (err instanceof AdminApiError) {
+          setError('Unable to load admin data');
+        } else {
+          setError('Unexpected error fetching admin data');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  const handleMenuFieldChange = (menuId: string, field: keyof AdminMenu, value: unknown) => {
+    setMenus((prev) =>
+      prev.map((menu) =>
+        menu.id === menuId
+          ? {
+              ...menu,
+              [field]: value,
+            }
+          : menu,
+      ),
+    );
+  };
+
+  const handleMenuItemChange = (menuId: string, itemId: string, field: keyof AdminMenuItem, value: unknown) => {
+    setMenus((prev) =>
+      prev.map((menu) => {
+        if (menu.id !== menuId) {
+          return menu;
+        }
+        return {
+          ...menu,
+          items: menu.items.map((item) => (item.id === itemId ? { ...item, [field]: value } : item)),
+        };
+      }),
+    );
+  };
+
+const handleAddMenu = () => {
+  const tempId = `temp-menu-${Date.now()}`;
+  setMenus((prev) => [emptyMenu(tempId), ...prev]);
+};
+
+  const handleAddItem = (menuId: string) => {
+    const tempId = `temp-item-${Date.now()}`;
+    setMenus((prev) =>
+      prev.map((menu) =>
+        menu.id === menuId
+          ? {
+              ...menu,
+              items: [...menu.items, emptyMenuItem(tempId)],
+            }
+          : menu,
+      ),
+    );
+  };
+
+  const handleRemoveItem = (menuId: string, itemId: string) => {
+    setMenus((prev) =>
+      prev.map((menu) =>
+        menu.id === menuId
+          ? {
+              ...menu,
+              items: menu.items.filter((item) => item.id !== itemId),
+            }
+          : menu,
+      ),
+    );
+  };
+
+  const handleDeleteMenu = async (menuId: string) => {
+    if (!menuId || menuId.startsWith('temp-menu-')) {
+      setMenus((prev) => prev.filter((menu) => menu.id !== menuId));
+      return;
+    }
+    await adminApi.deleteMenu(menuId);
+    setMenus((prev) => prev.filter((menu) => menu.id !== menuId));
+  };
+
+  const handleSaveMenu = async (menu: AdminMenu) => {
+    const isNew = menu.id.startsWith('temp-menu-');
+    setSavingMenuId(isNew ? 'new' : menu.id);
+    try {
+      setError(null);
+      const payload = {
+        ...menu,
+        id: isNew ? undefined : menu.id,
+        items: menu.items.map((item) => ({
+          ...item,
+          id: item.id?.startsWith('temp-item-') ? null : item.id,
+        })),
+      };
+      const saved = await adminApi.saveMenu(payload);
+      if (saved) {
+        setMenus((prev) => prev.map((entry) => (entry.id === menu.id ? saved : entry)));
+      } else {
+        const refreshed = await adminApi.menus();
+        setMenus(refreshed);
+      }
+    } catch (err) {
+      setError('Failed to save menu');
+    } finally {
+      setSavingMenuId(null);
+    }
+  };
+
+  const handleSaveOverride = async (override: Partial<AdminPricingOverride>) => {
+    const isNew = !override.id || override.id.startsWith('temp-override-');
+    setSavingOverrideId(isNew ? 'new' : override.id ?? null);
+    try {
+      setError(null);
+      if (!override.menuItemId || !override.menuItemId.trim()) {
+        setError('A menu item ID is required for pricing overrides');
+        return null;
+      }
+      if (override.price === undefined || Number.isNaN(Number(override.price))) {
+        setError('A numeric price is required for pricing overrides');
+        return null;
+      }
+      const payload = {
+        ...override,
+        id: isNew ? undefined : override.id,
+      };
+      const saved = await adminApi.savePricingOverride(payload);
+      const refreshed = await adminApi.pricingOverrides();
+      setPricingOverrides(refreshed);
+      return saved;
+    } catch (err) {
+      setError('Failed to save pricing override');
+      throw err;
+    } finally {
+      setSavingOverrideId(null);
+    }
+  };
+
+  const handleDeleteOverride = async (id: string) => {
+    if (id.startsWith('temp-override-')) {
+      setPricingOverrides((prev) => prev.filter((entry) => entry.id !== id));
+      return;
+    }
+    await adminApi.deletePricingOverride(id);
+    setPricingOverrides((prev) => prev.filter((entry) => entry.id !== id));
+  };
+
+  const handleSaveOperatingHour = async (hour: Partial<AdminOperatingHour>) => {
+    const isNew = !hour.id || hour.id.startsWith('temp-hour-');
+    setSavingHourId(isNew ? 'new' : hour.id ?? null);
+    try {
+      setError(null);
+      if (hour.opensAt === undefined || hour.closesAt === undefined) {
+        setError('Operating hours require opening and closing times');
+        return null;
+      }
+      const payload = {
+        ...hour,
+        id: isNew ? undefined : hour.id,
+      };
+      const saved = await adminApi.saveOperatingHour(payload);
+      const refreshed = await adminApi.operatingHours();
+      setOperatingHours(refreshed);
+      return saved;
+    } catch (err) {
+      setError('Failed to save operating hour');
+      throw err;
+    } finally {
+      setSavingHourId(null);
+    }
+  };
+
+  const handleDeleteOperatingHour = async (id: string) => {
+    if (id.startsWith('temp-hour-')) {
+      setOperatingHours((prev) => prev.filter((entry) => entry.id !== id));
+      return;
+    }
+    await adminApi.deleteOperatingHour(id);
+    setOperatingHours((prev) => prev.filter((entry) => entry.id !== id));
+  };
+
+  const handleAddOverride = () => {
+    const tempId = `temp-override-${Date.now()}`;
+    setPricingOverrides((prev) => [
+      {
+        id: tempId,
+        menuItemId: '',
+        price: 0,
+        currency: 'USD',
+        startsAt: null,
+        endsAt: null,
+        reason: '',
+      },
+      ...prev,
+    ]);
+  };
+
+  const handleAddOperatingHour = () => {
+    const tempId = `temp-hour-${Date.now()}`;
+    setOperatingHours((prev) => [
+      {
+        id: tempId,
+        dayOfWeek: 0,
+        opensAt: '09:00',
+        closesAt: '21:00',
+        isClosed: false,
+      },
+      ...prev,
+    ]);
+  };
+
+  const sortedHours = useMemo(() => operatingHours.slice().sort((a, b) => a.dayOfWeek - b.dayOfWeek), [operatingHours]);
+
+  if (loading) {
+    return <p className="text-sm text-slate-300">Loading menus…</p>;
+  }
+
+  return (
+    <div className="space-y-10">
+      <div>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-slate-100">Menu management</h1>
+          <Button type="button" variant="outline" size="sm" onClick={handleAddMenu}>
+            New menu
+          </Button>
+        </div>
+        <p className="mt-2 text-sm text-slate-400">
+          Edit menu names, toggle availability, and manage items across your catalog.
+        </p>
+        {error ? <p className="mt-3 text-sm text-red-400">{error}</p> : null}
+      </div>
+
+      <div className="space-y-8">
+        {menus.map((menu) => (
+          <Card key={menu.id || `unsaved-${menu.name}`} className="border-slate-800 bg-slate-900/60 text-slate-100">
+            <CardContent className="space-y-6 p-6">
+              <div className="flex flex-wrap items-center gap-4">
+              <div className="flex-1 space-y-3">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="space-y-2 text-sm text-slate-300">
+                    <Label htmlFor={`menu-${menu.id}-name`} className="text-slate-300">
+                      Menu name
+                    </Label>
+                    <Input
+                      id={`menu-${menu.id}-name`}
+                      value={menu.name}
+                      onChange={(event) => handleMenuFieldChange(menu.id, 'name', event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2 text-sm text-slate-300">
+                    <Label htmlFor={`menu-${menu.id}-translation`} className="text-slate-300">
+                      Translation key
+                    </Label>
+                    <Input
+                      id={`menu-${menu.id}-translation`}
+                      value={menu.translationKey ?? ''}
+                      onChange={(event) => handleMenuFieldChange(menu.id, 'translationKey', event.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2 text-sm text-slate-300">
+                  <Label htmlFor={`menu-${menu.id}-description`} className="text-slate-300">
+                    Description
+                  </Label>
+                  <Textarea
+                    id={`menu-${menu.id}-description`}
+                    value={menu.description ?? ''}
+                    rows={2}
+                    onChange={(event) => handleMenuFieldChange(menu.id, 'description', event.target.value)}
+                  />
+                </div>
+                <label className="inline-flex items-center gap-2 text-sm text-slate-200">
+                  <input
+                    type="checkbox"
+                    checked={menu.isActive}
+                    onChange={(event) => handleMenuFieldChange(menu.id, 'isActive', event.target.checked)}
+                    className="h-4 w-4 rounded border-slate-600 bg-slate-950"
+                  />
+                  Menu is active
+                </label>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Button
+                  type="button"
+                  onClick={() => handleSaveMenu(menu)}
+                  disabled={
+                    savingMenuId !== null &&
+                    (savingMenuId === menu.id || (savingMenuId === 'new' && menu.id.startsWith('temp-menu-')))
+                  }
+                >
+                  {savingMenuId !== null &&
+                  (savingMenuId === menu.id || (savingMenuId === 'new' && menu.id.startsWith('temp-menu-')))
+                    ? 'Saving…'
+                    : 'Save changes'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="border-red-900/40 text-red-300 hover:bg-red-900/20"
+                  onClick={() => handleDeleteMenu(menu.id)}
+                >
+                  Delete menu
+                </Button>
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-slate-100">Menu items</h3>
+                <Button type="button" variant="outline" size="sm" onClick={() => handleAddItem(menu.id)}>
+                  Add item
+                </Button>
+              </div>
+              <div className="space-y-4">
+                {menu.items.length === 0 ? (
+                  <p className="text-sm text-slate-400">No items yet. Add your first item to this menu.</p>
+                ) : (
+                  menu.items.map((item) => (
+                    <Card key={item.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                      <CardContent className="space-y-3 p-4 text-sm">
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <div className="space-y-2">
+                            <Label htmlFor={`item-${item.id}-name`} className="text-slate-300">
+                              Item name
+                            </Label>
+                            <Input
+                              id={`item-${item.id}-name`}
+                              value={item.name}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'name', event.target.value)}
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <Label htmlFor={`item-${item.id}-category`} className="text-slate-300">
+                              Category
+                            </Label>
+                            <Input
+                              id={`item-${item.id}-category`}
+                              value={item.categoryKey ?? ''}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'categoryKey', event.target.value)}
+                            />
+                          </div>
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor={`item-${item.id}-description`} className="text-slate-300">
+                            Description
+                          </Label>
+                          <Textarea
+                            id={`item-${item.id}-description`}
+                            value={item.description ?? ''}
+                            rows={2}
+                            onChange={(event) => handleMenuItemChange(menu.id, item.id, 'description', event.target.value)}
+                          />
+                        </div>
+                        <div className="grid gap-3 md:grid-cols-4">
+                          <div className="space-y-2">
+                            <Label htmlFor={`item-${item.id}-price`} className="text-slate-300">
+                              Price
+                            </Label>
+                            <Input
+                              id={`item-${item.id}-price`}
+                              type="number"
+                              value={item.price}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'price', Number(event.target.value))}
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <Label htmlFor={`item-${item.id}-currency`} className="text-slate-300">
+                              Currency
+                            </Label>
+                            <Input
+                              id={`item-${item.id}-currency`}
+                              value={item.currency}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'currency', event.target.value)}
+                            />
+                          </div>
+                          <label className="flex items-center gap-2 text-slate-200">
+                            <input
+                              type="checkbox"
+                              checked={item.isAvailable}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'isAvailable', event.target.checked)}
+                              className="h-4 w-4 rounded border-slate-600 bg-slate-950"
+                            />
+                            Available
+                          </label>
+                          <label className="flex items-center gap-2 text-slate-200">
+                            <input
+                              type="checkbox"
+                              checked={item.isPopular ?? false}
+                              onChange={(event) => handleMenuItemChange(menu.id, item.id, 'isPopular', event.target.checked)}
+                              className="h-4 w-4 rounded border-slate-600 bg-slate-950"
+                            />
+                            Mark as popular
+                          </label>
+                        </div>
+                      </CardContent>
+                      <CardFooter className="justify-end border-t border-slate-800 bg-transparent px-4 py-3">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="border-red-900/40 text-red-300 hover:bg-red-900/20"
+                          onClick={() => handleRemoveItem(menu.id, item.id)}
+                        >
+                          Remove item
+                        </Button>
+                      </CardFooter>
+                    </Card>
+                  ))
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        ))}
+      </div>
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle className="text-xl text-slate-100">Pricing overrides</CardTitle>
+              <CardDescription className="text-slate-400">
+                Configure time-bound discounts and pricing adjustments for specific items.
+              </CardDescription>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={handleAddOverride}>
+              Add override
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {pricingOverrides.length === 0 ? (
+            <p className="text-sm text-slate-400">No overrides configured.</p>
+          ) : (
+            pricingOverrides.map((override) => {
+              const savingCurrentOverride =
+                savingOverrideId !== null &&
+                (savingOverrideId === override.id ||
+                  (savingOverrideId === 'new' && override.id.startsWith('temp-override-')));
+
+              return (
+                <Card key={override.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                  <CardContent className="space-y-4 p-4 text-sm">
+                    <div className="grid gap-3 md:grid-cols-4">
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-item`} className="text-slate-300">
+                          Menu item ID
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-item`}
+                          value={override.menuItemId}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id ? { ...entry, menuItemId: event.target.value } : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-price`} className="text-slate-300">
+                          Price
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-price`}
+                          type="number"
+                          value={override.price}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id
+                                  ? { ...entry, price: Number(event.target.value) }
+                                  : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-currency`} className="text-slate-300">
+                          Currency
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-currency`}
+                          value={override.currency}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id ? { ...entry, currency: event.target.value } : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-reason`} className="text-slate-300">
+                          Reason
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-reason`}
+                          value={override.reason ?? ''}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id ? { ...entry, reason: event.target.value } : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                    </div>
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-start`} className="text-slate-300">
+                          Starts at
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-start`}
+                          type="datetime-local"
+                          value={override.startsAt ? override.startsAt.slice(0, 16) : ''}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id
+                                  ? {
+                                      ...entry,
+                                      startsAt: event.target.value ? new Date(event.target.value).toISOString() : null,
+                                    }
+                                  : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor={`override-${override.id}-end`} className="text-slate-300">
+                          Ends at
+                        </Label>
+                        <Input
+                          id={`override-${override.id}-end`}
+                          type="datetime-local"
+                          value={override.endsAt ? override.endsAt.slice(0, 16) : ''}
+                          onChange={(event) =>
+                            setPricingOverrides((prev) =>
+                              prev.map((entry) =>
+                                entry.id === override.id
+                                  ? {
+                                      ...entry,
+                                      endsAt: event.target.value ? new Date(event.target.value).toISOString() : null,
+                                    }
+                                  : entry,
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                    </div>
+                  </CardContent>
+                  <CardFooter className="justify-end gap-3 border-t border-slate-800 bg-transparent px-4 py-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="border-red-900/40 text-red-300 hover:bg-red-900/20"
+                      onClick={() => handleDeleteOverride(override.id)}
+                    >
+                      Remove
+                    </Button>
+                    <Button type="button" size="sm" onClick={() => handleSaveOverride({ ...override })} disabled={savingCurrentOverride}>
+                      {savingCurrentOverride ? 'Saving…' : 'Save override'}
+                    </Button>
+                  </CardFooter>
+                </Card>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle className="text-xl text-slate-100">Operating hours</CardTitle>
+              <CardDescription className="text-slate-400">
+                Define the hours of operation for dine-in and delivery.
+              </CardDescription>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={handleAddOperatingHour}>
+              Add schedule
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {sortedHours.length === 0 ? (
+            <p className="text-sm text-slate-400">No schedules configured.</p>
+          ) : (
+            sortedHours.map((hour) => {
+              const savingCurrentHour =
+                savingHourId !== null &&
+                (savingHourId === hour.id || (savingHourId === 'new' && hour.id.startsWith('temp-hour-')));
+
+              return (
+                <Card key={hour.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                  <CardContent className="grid gap-3 p-4 text-sm md:grid-cols-5">
+                    <div className="space-y-2">
+                      <Label htmlFor={`hour-${hour.id}-day`} className="text-slate-300">
+                        Day
+                      </Label>
+                      <Select
+                        id={`hour-${hour.id}-day`}
+                        value={hour.dayOfWeek}
+                        onChange={(event) =>
+                          setOperatingHours((prev) =>
+                            prev.map((entry) =>
+                              entry.id === hour.id ? { ...entry, dayOfWeek: Number(event.target.value) } : entry,
+                            ),
+                          )
+                        }
+                      >
+                        {dayNames.map((name, index) => (
+                          <option key={name} value={index}>
+                            {name}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`hour-${hour.id}-open`} className="text-slate-300">
+                        Opens
+                      </Label>
+                      <Input
+                        id={`hour-${hour.id}-open`}
+                        value={hour.opensAt}
+                        onChange={(event) =>
+                          setOperatingHours((prev) =>
+                            prev.map((entry) =>
+                              entry.id === hour.id ? { ...entry, opensAt: event.target.value } : entry,
+                            ),
+                          )
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`hour-${hour.id}-close`} className="text-slate-300">
+                        Closes
+                      </Label>
+                      <Input
+                        id={`hour-${hour.id}-close`}
+                        value={hour.closesAt}
+                        onChange={(event) =>
+                          setOperatingHours((prev) =>
+                            prev.map((entry) =>
+                              entry.id === hour.id ? { ...entry, closesAt: event.target.value } : entry,
+                            ),
+                          )
+                        }
+                      />
+                    </div>
+                    <label className="flex items-center gap-2 text-slate-200">
+                      <input
+                        type="checkbox"
+                        checked={hour.isClosed ?? false}
+                        onChange={(event) =>
+                          setOperatingHours((prev) =>
+                            prev.map((entry) =>
+                              entry.id === hour.id ? { ...entry, isClosed: event.target.checked } : entry,
+                            ),
+                          )
+                        }
+                        className="h-4 w-4 rounded border-slate-600 bg-slate-950"
+                      />
+                      Closed
+                    </label>
+                  </CardContent>
+                  <CardFooter className="justify-end gap-2 border-t border-slate-800 bg-transparent px-4 py-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="border-red-900/40 text-red-300 hover:bg-red-900/20"
+                      onClick={() => handleDeleteOperatingHour(hour.id)}
+                    >
+                      Remove
+                    </Button>
+                    <Button type="button" size="sm" onClick={() => handleSaveOperatingHour(hour)} disabled={savingCurrentHour}>
+                      {savingCurrentHour ? 'Saving…' : 'Save hours'}
+                    </Button>
+                  </CardFooter>
+                </Card>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AdminApiError, AdminOrder, adminApi } from '@/lib/admin-api';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+
+const STATUSES = ['all', 'pending', 'confirmed', 'prepared', 'delivered', 'cancelled'] as const;
+
+type StatusFilter = (typeof STATUSES)[number];
+
+const formatDateTime = (iso: string) => new Date(iso).toLocaleString();
+
+export default function AdminOrdersPage() {
+  const [orders, setOrders] = useState<AdminOrder[]>([]);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const loadOrders = async () => {
+    setLoading(true);
+    try {
+      const result = await adminApi.orders();
+      setOrders(result);
+      setError(null);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setError('Unable to load orders');
+      } else {
+        setError('Unexpected error fetching orders');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadOrders();
+  }, []);
+
+  const filteredOrders = useMemo(() => {
+    if (statusFilter === 'all') {
+      return orders;
+    }
+    return orders.filter((order) => order.status === statusFilter);
+  }, [orders, statusFilter]);
+
+  return (
+    <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+      <CardHeader className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <CardTitle className="text-2xl text-slate-100">Order dashboard</CardTitle>
+            <CardDescription className="text-slate-400">
+              Monitor the latest 100 orders, their statuses, and customer details.
+            </CardDescription>
+            {lastUpdated ? (
+              <p className="mt-1 text-xs text-slate-500">Last refreshed {lastUpdated.toLocaleTimeString()}</p>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-3 text-sm">
+            <Select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}>
+              {STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status === 'all' ? 'All statuses' : status.charAt(0).toUpperCase() + status.slice(1)}
+                </option>
+              ))}
+            </Select>
+            <Button type="button" variant="outline" onClick={loadOrders}>
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error ? <p className="text-sm text-red-400">{error}</p> : null}
+        {loading ? (
+          <p className="text-sm text-slate-300">Loading orders…</p>
+        ) : filteredOrders.length === 0 ? (
+          <p className="text-sm text-slate-400">No orders found for the selected status.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-800">
+              <thead className="bg-slate-900/60 text-left text-xs uppercase tracking-wide text-slate-400">
+                <tr>
+                  <th className="px-4 py-3">Order ID</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Items</th>
+                  <th className="px-4 py-3">Total</th>
+                  <th className="px-4 py-3">Customer</th>
+                  <th className="px-4 py-3">Submitted</th>
+                  <th className="px-4 py-3">Notes</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-900/60 text-sm text-slate-200">
+                {filteredOrders.map((order) => (
+                  <tr key={order.id} className="hover:bg-slate-900/40">
+                    <td className="px-4 py-3 font-mono text-xs text-slate-400">{order.id}</td>
+                    <td className="px-4 py-3 capitalize">{order.status}</td>
+                    <td className="px-4 py-3">{order.itemCount}</td>
+                    <td className="px-4 py-3">
+                      {order.total.toFixed(2)} {order.currency}
+                    </td>
+                    <td className="px-4 py-3">
+                      {order.customer ? (
+                        <div className="space-y-1 text-xs text-slate-300">
+                          {order.customer.name ? <p>{order.customer.name}</p> : null}
+                          {order.customer.phone ? <p>{order.customer.phone}</p> : null}
+                          {order.customer.email ? <p>{order.customer.email}</p> : null}
+                        </div>
+                      ) : (
+                        <span className="text-xs text-slate-500">Walk-in</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-slate-400">{formatDateTime(order.submittedAt)}</td>
+                    <td className="px-4 py-3 text-xs text-slate-300">{order.notes ?? '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import { useAdminSession } from '@/components/admin/AdminGuard';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AdminHomePage() {
+  const context = useAdminSession();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-100">Welcome back{context ? `, ${context.session.name ?? context.session.email}` : ''}!</h1>
+        <p className="mt-2 text-sm text-slate-300">
+          Use the navigation to manage menus, monitor incoming orders, register devices, and review performance reports.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {[
+          {
+            href: '/admin/menus',
+            title: 'Manage menus',
+            description: 'Update pricing, availability, and descriptions in real-time.',
+          },
+          {
+            href: '/admin/orders',
+            title: 'Track orders',
+            description: 'Monitor active orders and customer details as they flow in.',
+          },
+          {
+            href: '/admin/devices',
+            title: 'Devices',
+            description: 'Register kiosks, tablets, and mobile devices for in-store experiences.',
+          },
+          {
+            href: '/admin/reports',
+            title: 'Reports',
+            description: 'Run daily sales and popularity reports to stay on top of trends.',
+          },
+        ].map((item) => (
+          <Card
+            key={item.href}
+            className="border-slate-800 bg-slate-900/60 text-slate-100 transition hover:border-slate-700 hover:bg-slate-900"
+          >
+            <Link href={item.href} className="flex h-full flex-col">
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-lg text-slate-100">{item.title}</CardTitle>
+                <CardDescription className="text-slate-300">{item.description}</CardDescription>
+              </CardHeader>
+            </Link>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AdminApiError, AdminReport, adminApi } from '@/lib/admin-api';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+const formatDate = (iso: string) => new Date(iso).toLocaleString();
+
+export default function AdminReportsPage() {
+  const [dailyReports, setDailyReports] = useState<AdminReport[]>([]);
+  const [popularReports, setPopularReports] = useState<AdminReport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [runningReport, setRunningReport] = useState<'daily' | 'popular' | null>(null);
+
+  const loadReports = async () => {
+    setLoading(true);
+    try {
+      const [daily, popular] = await Promise.all([
+        adminApi.reports('daily-sales'),
+        adminApi.reports('popular-items'),
+      ]);
+      setDailyReports(daily);
+      setPopularReports(popular);
+      setError(null);
+    } catch (err) {
+      if (err instanceof AdminApiError) {
+        setError('Unable to load reports');
+      } else {
+        setError('Unexpected error fetching reports');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadReports();
+  }, []);
+
+  const runDailySales = async () => {
+    setRunningReport('daily');
+    try {
+      await adminApi.runDailySales();
+      await loadReports();
+    } catch (err) {
+      setError('Failed to generate daily sales report');
+    } finally {
+      setRunningReport(null);
+    }
+  };
+
+  const runPopularItems = async () => {
+    setRunningReport('popular');
+    try {
+      await adminApi.runPopularItems();
+      await loadReports();
+    } catch (err) {
+      setError('Failed to generate popular items report');
+    } finally {
+      setRunningReport(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-100">Reports and insights</h1>
+        <p className="mt-2 text-sm text-slate-400">Generate aggregated sales and product performance reports.</p>
+      </div>
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+      {loading ? <p className="text-sm text-slate-300">Loading reports…</p> : null}
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="text-xl text-slate-100">Daily sales</CardTitle>
+            <CardDescription className="text-slate-400">
+              Compute total sales and currency breakdown for the latest day.
+            </CardDescription>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={runDailySales} disabled={runningReport === 'daily'}>
+            {runningReport === 'daily' ? 'Generating…' : 'Run report'}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {dailyReports.length === 0 ? (
+            <p className="text-sm text-slate-400">No reports generated yet.</p>
+          ) : (
+            dailyReports.map((report) => {
+              const payload = report.payload as {
+                total: number;
+                currencyBreakdown: Record<string, number>;
+                orderCount: number;
+              };
+              return (
+                <Card key={report.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                  <CardContent className="space-y-4 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-4">
+                      <div>
+                        <CardTitle className="text-lg text-slate-100">{formatDate(report.rangeStart)}</CardTitle>
+                        <p className="text-xs text-slate-500">Generated {formatDate(report.generatedAt)}</p>
+                      </div>
+                      <div className="text-right text-sm text-slate-200">
+                        <p className="text-base font-semibold text-slate-100">Total: {payload.total.toFixed(2)}</p>
+                        <p className="text-xs text-slate-400">Orders: {payload.orderCount}</p>
+                      </div>
+                    </div>
+                    <div className="grid gap-2 md:grid-cols-3">
+                      {Object.entries(payload.currencyBreakdown).map(([currency, value]) => (
+                        <div key={currency} className="rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-200">
+                          <p className="text-xs uppercase text-slate-400">{currency}</p>
+                          <p className="text-base font-semibold">{value.toFixed(2)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-slate-800 bg-slate-900/60 text-slate-100">
+        <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle className="text-xl text-slate-100">Popular items</CardTitle>
+            <CardDescription className="text-slate-400">
+              Identify top-performing menu items over the last seven days.
+            </CardDescription>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={runPopularItems} disabled={runningReport === 'popular'}>
+            {runningReport === 'popular' ? 'Generating…' : 'Run report'}
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {popularReports.length === 0 ? (
+            <p className="text-sm text-slate-400">No popular item reports generated yet.</p>
+          ) : (
+            popularReports.map((report) => {
+              const payload = report.payload as Array<{
+                menuItemId: string;
+                name: string;
+                quantity: number;
+                revenue: number;
+              }>;
+              return (
+                <Card key={report.id} className="border-slate-800 bg-slate-950/60 text-slate-100">
+                  <CardContent className="space-y-4 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-4">
+                      <div>
+                        <CardTitle className="text-lg text-slate-100">
+                          {formatDate(report.rangeStart)} → {formatDate(report.rangeEnd)}
+                        </CardTitle>
+                        <p className="text-xs text-slate-500">Generated {formatDate(report.generatedAt)}</p>
+                      </div>
+                      <div className="text-right text-sm text-slate-200">
+                        <p className="text-xs text-slate-400">Top {payload.length} items</p>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      {payload.map((item) => (
+                        <div key={item.menuItemId} className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-2 text-sm text-slate-200">
+                          <div>
+                            <p className="font-semibold text-slate-100">{item.name}</p>
+                            <p className="text-xs text-slate-400">ID: {item.menuItemId}</p>
+                          </div>
+                          <div className="text-right text-xs text-slate-300">
+                            <p>Qty: {item.quantity}</p>
+                            <p>Revenue: {item.revenue.toFixed(2)}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Select({ className, ...props }: React.ComponentProps<"select">) {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        "border-input flex h-9 w-full rounded-md border bg-transparent px-3 text-sm shadow-xs transition-[color,box-shadow] outline-none",
+        "appearance-none bg-[url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 20 20\'%3E%3Cpath fill=\'none\' stroke='",
+        "currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E')] bg-[position:calc(100%-0.75rem)_50%] bg-[size:1rem] bg-no-repeat",
+        "pr-8", // space for arrow
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Select }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input flex min-h-[120px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none md:text-sm",
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/services/api/src/config.ts
+++ b/services/api/src/config.ts
@@ -16,6 +16,8 @@ export interface AppConfig {
   mongoDbName: string;
   tenantHostMap: Record<string, string>;
   baseDomain?: string;
+  adminJwtSecret: string;
+  adminSessionTtlSeconds: number;
 }
 
 const parseTenantMap = (raw: string | undefined): Record<string, string> => {
@@ -44,4 +46,6 @@ export const config: AppConfig = {
   mongoDbName: requiredEnv('MONGO_DB_NAME'),
   tenantHostMap: parseTenantMap(process.env.TENANT_HOST_MAP),
   baseDomain: process.env.TENANT_BASE_DOMAIN,
+  adminJwtSecret: requiredEnv('ADMIN_JWT_SECRET'),
+  adminSessionTtlSeconds: Number.parseInt(process.env.ADMIN_SESSION_TTL ?? '3600', 10),
 };

--- a/services/api/src/db/schemas.ts
+++ b/services/api/src/db/schemas.ts
@@ -74,6 +74,38 @@ export interface TenantDocument extends BaseDocument {
   isActive: boolean;
 }
 
+export interface AdminUserDocument extends BaseDocument {
+  email: string;
+  passwordHash: string;
+  name?: string;
+  roles: string[];
+  lastLoginAt?: Date;
+}
+
+export interface PricingOverrideDocument extends BaseDocument {
+  menuItemId: string;
+  price: number;
+  currency: string;
+  startsAt?: Date;
+  endsAt?: Date;
+  reason?: string;
+}
+
+export interface OperatingHourDocument extends BaseDocument {
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+  isClosed?: boolean;
+}
+
+export interface ReportDocument extends BaseDocument {
+  reportType: 'daily-sales' | 'popular-items';
+  rangeStart: Date;
+  rangeEnd: Date;
+  generatedAt: Date;
+  payload: unknown;
+}
+
 export type TenantCollectionsShape = {
   menus: MenuDocument;
   menuItems: MenuItemDocument;
@@ -81,6 +113,10 @@ export type TenantCollectionsShape = {
   orders: OrderDocument;
   devices: DeviceDocument;
   tenants: TenantDocument;
+  adminUsers: AdminUserDocument;
+  pricingOverrides: PricingOverrideDocument;
+  operatingHours: OperatingHourDocument;
+  reports: ReportDocument;
 };
 
 export const COLLECTION_NAMES: { [K in keyof TenantCollectionsShape]: string } = {
@@ -90,4 +126,8 @@ export const COLLECTION_NAMES: { [K in keyof TenantCollectionsShape]: string } =
   orders: 'orders',
   devices: 'devices',
   tenants: 'tenants',
+  adminUsers: 'adminUsers',
+  pricingOverrides: 'pricingOverrides',
+  operatingHours: 'operatingHours',
+  reports: 'reports',
 };

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -7,6 +7,8 @@ import tenantResolverPlugin from './plugins/tenant-resolver';
 import menusRoutes from './routes/menus';
 import cartsRoutes from './routes/carts';
 import ordersRoutes from './routes/orders';
+import adminRoutes from './routes/admin';
+import authPlugin from './plugins/auth';
 
 const logger = pino({
   level: process.env.LOG_LEVEL ?? 'info',
@@ -23,10 +25,12 @@ export const buildServer = (): FastifyInstance => {
   });
 
   app.register(mongoPlugin);
+  app.register(authPlugin);
   app.register(tenantResolverPlugin);
   app.register(menusRoutes);
   app.register(cartsRoutes);
   app.register(ordersRoutes);
+  app.register(adminRoutes);
 
   app.get('/healthz', async () => ({ status: 'ok' }));
 

--- a/services/api/src/plugins/auth.ts
+++ b/services/api/src/plugins/auth.ts
@@ -1,0 +1,134 @@
+import fp from 'fastify-plugin';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { config } from '../config';
+
+type AdminJwtPayload = {
+  adminId: string;
+  tenantId: string;
+  exp: number;
+};
+
+const base64UrlEncode = (value: Buffer | string): string => {
+  return Buffer.from(value).toString('base64url');
+};
+
+const base64UrlDecode = (value: string): Buffer => {
+  return Buffer.from(value, 'base64url');
+};
+
+const signToken = (payload: AdminJwtPayload): string => {
+  const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  const signature = createHmac('sha256', config.adminJwtSecret)
+    .update(`${header}.${body}`)
+    .digest();
+  const sig = base64UrlEncode(signature);
+  return `${header}.${body}.${sig}`;
+};
+
+const verifyToken = (token: string): AdminJwtPayload | null => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [headerPart, payloadPart, signaturePart] = parts;
+  const expectedSignature = createHmac('sha256', config.adminJwtSecret)
+    .update(`${headerPart}.${payloadPart}`)
+    .digest();
+  const providedSignature = base64UrlDecode(signaturePart);
+
+  if (expectedSignature.length !== providedSignature.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(expectedSignature, providedSignature)) {
+    return null;
+  }
+
+  const payload = JSON.parse(base64UrlDecode(payloadPart).toString()) as AdminJwtPayload;
+  if (!payload.exp || payload.exp < Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+
+  return payload;
+};
+
+const extractToken = (request: FastifyRequest): string | null => {
+  const authHeader = request.headers.authorization;
+  if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
+    return authHeader.slice(7);
+  }
+
+  const cookieHeader = request.headers.cookie;
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';').map((entry) => entry.trim());
+  for (const cookie of cookies) {
+    const [key, ...rest] = cookie.split('=');
+    if (key === 'admin_token') {
+      return rest.join('=');
+    }
+  }
+
+  return null;
+};
+
+const setTokenCookie = (reply: FastifyReply, token: string): void => {
+  const maxAge = config.adminSessionTtlSeconds;
+  reply.header('set-cookie', `admin_token=${token}; HttpOnly; Path=/; Max-Age=${maxAge}; SameSite=Lax`);
+};
+
+const clearTokenCookie = (reply: FastifyReply): void => {
+  reply.header('set-cookie', 'admin_token=; HttpOnly; Path=/; Max-Age=0; SameSite=Lax');
+};
+
+export const authPlugin = fp(async (fastify: FastifyInstance) => {
+  fastify.decorate('signAdminToken', (payload: Omit<AdminJwtPayload, 'exp'>) => {
+    const exp = Math.floor(Date.now() / 1000) + config.adminSessionTtlSeconds;
+    return signToken({ ...payload, exp });
+  });
+
+  fastify.decorate('setAdminSessionCookie', setTokenCookie);
+  fastify.decorate('clearAdminSessionCookie', clearTokenCookie);
+
+  fastify.decorate('authenticate', async function (request: FastifyRequest, reply: FastifyReply) {
+    const token = extractToken(request);
+    if (!token) {
+      reply.code(401);
+      throw new Error('Missing authentication token');
+    }
+
+    const payload = verifyToken(token);
+    if (!payload || payload.tenantId !== request.tenantId) {
+      reply.code(401);
+      throw new Error('Invalid authentication token');
+    }
+
+    const collections = await request.getTenantCollections();
+    const adminUser = await collections.adminUsers.findOne({ resourceId: payload.adminId });
+    if (!adminUser) {
+      reply.code(401);
+      throw new Error('Unknown administrator');
+    }
+
+    request.adminUser = {
+      id: adminUser.resourceId,
+      email: adminUser.email,
+      name: adminUser.name,
+      roles: adminUser.roles,
+    };
+  });
+});
+
+export type AdminUserSession = {
+  id: string;
+  email: string;
+  name?: string;
+  roles: string[];
+};
+
+export default authPlugin;

--- a/services/api/src/routes/admin.ts
+++ b/services/api/src/routes/admin.ts
@@ -1,0 +1,818 @@
+import { FastifyInstance } from 'fastify';
+import { randomUUID } from 'crypto';
+import { verifyPassword } from '../services/password';
+import { MenuDocument, MenuItemDocument, PricingOverrideDocument, OperatingHourDocument, ReportDocument } from '../db/schemas';
+import type { TenantCollections } from '../db/mongo';
+
+const adminUserResponseSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    email: { type: 'string' },
+    name: { type: ['string', 'null'] },
+    roles: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['id', 'email', 'roles'],
+  additionalProperties: false,
+} as const;
+
+const loginBodySchema = {
+  type: 'object',
+  properties: {
+    email: { type: 'string', format: 'email' },
+    password: { type: 'string', minLength: 6 },
+  },
+  required: ['email', 'password'],
+  additionalProperties: false,
+} as const;
+
+const menuItemInputSchema = {
+  type: 'object',
+  properties: {
+    id: { type: ['string', 'null'] },
+    name: { type: 'string' },
+    description: { type: ['string', 'null'] },
+    categoryKey: { type: ['string', 'null'] },
+    price: { type: 'number' },
+    currency: { type: 'string' },
+    isAvailable: { type: 'boolean' },
+    imageUrl: { type: ['string', 'null'] },
+    isPopular: { type: ['boolean', 'null'] },
+    isNew: { type: ['boolean', 'null'] },
+  },
+  required: ['name', 'price', 'currency', 'isAvailable'],
+  additionalProperties: false,
+} as const;
+
+const menuInputSchema = {
+  type: 'object',
+  properties: {
+    id: { type: ['string', 'null'] },
+    name: { type: 'string' },
+    description: { type: ['string', 'null'] },
+    translationKey: { type: ['string', 'null'] },
+    isActive: { type: 'boolean' },
+    items: { type: 'array', items: menuItemInputSchema },
+  },
+  required: ['name', 'isActive', 'items'],
+  additionalProperties: false,
+} as const;
+
+type MenuItemInput = {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  categoryKey?: string | null;
+  price: number;
+  currency: string;
+  isAvailable: boolean;
+  imageUrl?: string | null;
+  isPopular?: boolean | null;
+  isNew?: boolean | null;
+};
+
+type MenuInput = {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  translationKey?: string | null;
+  isActive: boolean;
+  items: MenuItemInput[];
+};
+
+const pricingOverrideInputSchema = {
+  type: 'object',
+  properties: {
+    id: { type: ['string', 'null'] },
+    menuItemId: { type: 'string' },
+    price: { type: 'number' },
+    currency: { type: 'string' },
+    startsAt: { type: ['string', 'null'], format: 'date-time' },
+    endsAt: { type: ['string', 'null'], format: 'date-time' },
+    reason: { type: ['string', 'null'] },
+  },
+  required: ['menuItemId', 'price', 'currency'],
+  additionalProperties: false,
+} as const;
+
+const operatingHourInputSchema = {
+  type: 'object',
+  properties: {
+    id: { type: ['string', 'null'] },
+    dayOfWeek: { type: 'integer', minimum: 0, maximum: 6 },
+    opensAt: { type: 'string' },
+    closesAt: { type: 'string' },
+    isClosed: { type: ['boolean', 'null'] },
+  },
+  required: ['dayOfWeek', 'opensAt', 'closesAt'],
+  additionalProperties: false,
+} as const;
+
+const deviceInputSchema = {
+  type: 'object',
+  properties: {
+    id: { type: ['string', 'null'] },
+    label: { type: 'string' },
+    type: { type: 'string', enum: ['kiosk', 'tablet', 'mobile'] },
+  },
+  required: ['label', 'type'],
+  additionalProperties: false,
+} as const;
+
+const parseDate = (value: string | null | undefined): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return parsed;
+};
+
+const formatMenuItem = (doc: MenuItemDocument) => ({
+  id: doc.resourceId,
+  name: doc.name,
+  description: doc.description ?? null,
+  categoryKey: doc.categoryKey ?? null,
+  price: doc.price,
+  currency: doc.currency,
+  isAvailable: doc.isAvailable,
+  imageUrl: doc.imageUrl ?? null,
+  isPopular: doc.isPopular ?? false,
+  isNew: doc.isNew ?? false,
+});
+
+const formatMenu = (menu: MenuDocument, items: MenuItemDocument[]) => ({
+  id: menu.resourceId,
+  name: menu.name,
+  description: menu.description ?? null,
+  translationKey: menu.translationKey ?? null,
+  isActive: menu.isActive,
+  items: items.map(formatMenuItem),
+});
+
+const formatPricingOverride = (doc: PricingOverrideDocument) => ({
+  id: doc.resourceId,
+  menuItemId: doc.menuItemId,
+  price: doc.price,
+  currency: doc.currency,
+  startsAt: doc.startsAt?.toISOString() ?? null,
+  endsAt: doc.endsAt?.toISOString() ?? null,
+  reason: doc.reason ?? null,
+});
+
+const formatOperatingHour = (doc: OperatingHourDocument) => ({
+  id: doc.resourceId,
+  dayOfWeek: doc.dayOfWeek,
+  opensAt: doc.opensAt,
+  closesAt: doc.closesAt,
+  isClosed: doc.isClosed ?? false,
+});
+
+const formatReport = (doc: ReportDocument) => ({
+  id: doc.resourceId,
+  type: doc.reportType,
+  rangeStart: doc.rangeStart.toISOString(),
+  rangeEnd: doc.rangeEnd.toISOString(),
+  generatedAt: doc.generatedAt.toISOString(),
+  payload: doc.payload,
+});
+
+const ensureMenuItems = async (
+  menuId: string,
+  items: MenuItemInput[],
+  tenantCollections: TenantCollections,
+): Promise<void> => {
+  const existingItems = await tenantCollections.menuItems.find({ menuId }).toArray();
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const isTempId = item.id?.startsWith('temp-item-');
+    const resourceId = !item.id || isTempId ? randomUUID() : item.id;
+    seen.add(resourceId);
+    const payload = {
+      menuId,
+      name: item.name,
+      description: item.description ?? undefined,
+      categoryKey: item.categoryKey ?? undefined,
+      price: item.price,
+      currency: item.currency,
+      isAvailable: item.isAvailable,
+      imageUrl: item.imageUrl ?? undefined,
+      isPopular: item.isPopular ?? undefined,
+      isNew: item.isNew ?? undefined,
+    };
+
+    await tenantCollections.menuItems.updateOne(
+      { resourceId },
+      {
+        $setOnInsert: {
+          resourceId,
+          createdAt: new Date(),
+        },
+        $set: payload,
+      },
+      { upsert: true },
+    );
+  }
+
+  for (const existing of existingItems) {
+    if (!seen.has(existing.resourceId)) {
+      await tenantCollections.menuItems.deleteOne({ resourceId: existing.resourceId });
+    }
+  }
+};
+
+const calculateDailySalesPayload = async (
+  tenantCollections: TenantCollections,
+  rangeStart: Date,
+  rangeEnd: Date,
+) => {
+  const orders = await tenantCollections.orders
+    .find({ submittedAt: { $gte: rangeStart, $lt: rangeEnd } })
+    .toArray();
+
+  let total = 0;
+  const currencyCount: Record<string, number> = {};
+
+  for (const order of orders) {
+    total += order.total;
+    currencyCount[order.currency] = (currencyCount[order.currency] ?? 0) + order.total;
+  }
+
+  return {
+    total,
+    currencyBreakdown: currencyCount,
+    orderCount: orders.length,
+  };
+};
+
+const calculatePopularItemsPayload = async (
+  tenantCollections: TenantCollections,
+  rangeStart: Date,
+  rangeEnd: Date,
+) => {
+  const orders = await tenantCollections.orders
+    .find({ submittedAt: { $gte: rangeStart, $lt: rangeEnd } })
+    .toArray();
+
+  const counts = new Map<string, { quantity: number; revenue: number }>();
+
+  for (const order of orders) {
+    for (const item of order.items) {
+      const entry = counts.get(item.menuItemId) ?? { quantity: 0, revenue: 0 };
+      entry.quantity += item.quantity;
+      const averageLineTotal = order.items.length > 0 ? order.total / order.items.length : 0;
+      entry.revenue += averageLineTotal * item.quantity;
+      counts.set(item.menuItemId, entry);
+    }
+  }
+
+  const menuItems = await tenantCollections.menuItems.find({}).toArray();
+  const itemNameMap = new Map(menuItems.map((item) => [item.resourceId, item.name]));
+
+  return Array.from(counts.entries())
+    .map(([menuItemId, info]) => ({
+      menuItemId,
+      name: itemNameMap.get(menuItemId) ?? menuItemId,
+      quantity: info.quantity,
+      revenue: info.revenue,
+    }))
+    .sort((a, b) => b.quantity - a.quantity)
+    .slice(0, 20);
+};
+
+export default async function adminRoutes(app: FastifyInstance): Promise<void> {
+  app.post(
+    '/admin/auth/login',
+    {
+      schema: {
+        body: loginBodySchema,
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              admin: adminUserResponseSchema,
+              token: { type: 'string' },
+            },
+            required: ['admin', 'token'],
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { email, password } = request.body as { email: string; password: string };
+      const collections = await request.getTenantCollections();
+      const adminUser = await collections.adminUsers.findOne({ email: email.toLowerCase() });
+
+      if (!adminUser || !verifyPassword(password, adminUser.passwordHash)) {
+        reply.code(401);
+        return { message: 'Invalid credentials' };
+      }
+
+      const token = app.signAdminToken({ adminId: adminUser.resourceId, tenantId: request.tenantId });
+      app.setAdminSessionCookie(reply, token);
+
+      await collections.adminUsers.updateOne(
+        { resourceId: adminUser.resourceId },
+        { $set: { lastLoginAt: new Date() } },
+      );
+
+      return {
+        admin: {
+          id: adminUser.resourceId,
+          email: adminUser.email,
+          name: adminUser.name ?? null,
+          roles: adminUser.roles,
+        },
+        token,
+      };
+    },
+  );
+
+  app.post(
+    '/admin/auth/logout',
+    { preHandler: app.authenticate },
+    async (_request, reply) => {
+      app.clearAdminSessionCookie(reply);
+      return { success: true };
+    },
+  );
+
+  app.get(
+    '/admin/auth/session',
+    { preHandler: app.authenticate },
+    async (request) => {
+      return { admin: request.adminUser };
+    },
+  );
+
+  app.get(
+    '/admin/menus',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+      const menus = await collections.menus.find({}).toArray();
+      const items = await collections.menuItems.find({}).toArray();
+      const itemsByMenu = new Map<string, MenuItemDocument[]>();
+      for (const item of items) {
+        const list = itemsByMenu.get(item.menuId) ?? [];
+        list.push(item);
+        itemsByMenu.set(item.menuId, list);
+      }
+
+      return {
+        menus: menus.map((menu) => formatMenu(menu, itemsByMenu.get(menu.resourceId) ?? [])),
+      };
+    },
+  );
+
+  app.post(
+    '/admin/menus',
+    { preHandler: app.authenticate, schema: { body: menuInputSchema } },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const body = request.body as MenuInput;
+
+      const resourceId = body.id && body.id.length > 0 ? body.id : randomUUID();
+
+      await collections.menus.updateOne(
+        { resourceId },
+        {
+          $setOnInsert: { resourceId, createdAt: new Date() },
+          $set: {
+            name: body.name,
+            description: body.description ?? undefined,
+            translationKey: body.translationKey ?? undefined,
+            isActive: body.isActive,
+          },
+        },
+        { upsert: true },
+      );
+
+      await ensureMenuItems(resourceId, body.items, collections);
+
+      const menuDoc = await collections.menus.findOne({ resourceId });
+      const menuItems = await collections.menuItems.find({ menuId: resourceId }).toArray();
+
+      reply.code(201);
+      return { menu: menuDoc ? formatMenu(menuDoc, menuItems) : null };
+    },
+  );
+
+  app.put(
+    '/admin/menus/:menuId',
+    { preHandler: app.authenticate, schema: { body: menuInputSchema } },
+    async (request) => {
+      const { menuId } = request.params as { menuId: string };
+      const collections = await request.getTenantCollections();
+      const body = request.body as MenuInput;
+
+      const menu = await collections.menus.findOne({ resourceId: menuId });
+      if (!menu) {
+        return { message: 'Menu not found' };
+      }
+
+      await collections.menus.updateOne(
+        { resourceId: menuId },
+        {
+          $set: {
+            name: body.name,
+            description: body.description ?? undefined,
+            translationKey: body.translationKey ?? undefined,
+            isActive: body.isActive,
+          },
+        },
+      );
+
+      await ensureMenuItems(menuId, body.items, collections);
+
+      const updatedMenu = await collections.menus.findOne({ resourceId: menuId });
+      const menuItems = await collections.menuItems.find({ menuId }).toArray();
+
+      return { menu: updatedMenu ? formatMenu(updatedMenu, menuItems) : null };
+    },
+  );
+
+  app.delete(
+    '/admin/menus/:menuId',
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const { menuId } = request.params as { menuId: string };
+      const collections = await request.getTenantCollections();
+      await collections.menus.deleteOne({ resourceId: menuId });
+      await collections.menuItems.deleteMany({ menuId });
+      reply.code(204);
+    },
+  );
+
+  app.get(
+    '/admin/pricing-overrides',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+      const overrides = await collections.pricingOverrides.find({}).toArray();
+      return { overrides: overrides.map(formatPricingOverride) };
+    },
+  );
+
+  app.post(
+    '/admin/pricing-overrides',
+    { preHandler: app.authenticate, schema: { body: pricingOverrideInputSchema } },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const body = request.body as {
+        id?: string | null;
+        menuItemId: string;
+        price: number;
+        currency: string;
+        startsAt?: string | null;
+        endsAt?: string | null;
+        reason?: string | null;
+      };
+
+      const resourceId = body.id && body.id.length > 0 ? body.id : randomUUID();
+      await collections.pricingOverrides.updateOne(
+        { resourceId },
+        {
+          $setOnInsert: { resourceId, createdAt: new Date() },
+          $set: {
+            menuItemId: body.menuItemId,
+            price: body.price,
+            currency: body.currency,
+            startsAt: parseDate(body.startsAt ?? undefined),
+            endsAt: parseDate(body.endsAt ?? undefined),
+            reason: body.reason ?? undefined,
+          },
+        },
+        { upsert: true },
+      );
+
+      const override = await collections.pricingOverrides.findOne({ resourceId });
+      reply.code(201);
+      return { override: override ? formatPricingOverride(override) : null };
+    },
+  );
+
+  app.put(
+    '/admin/pricing-overrides/:overrideId',
+    { preHandler: app.authenticate, schema: { body: pricingOverrideInputSchema } },
+    async (request) => {
+      const { overrideId } = request.params as { overrideId: string };
+      const collections = await request.getTenantCollections();
+      const body = request.body as {
+        menuItemId: string;
+        price: number;
+        currency: string;
+        startsAt?: string | null;
+        endsAt?: string | null;
+        reason?: string | null;
+      };
+
+      await collections.pricingOverrides.updateOne(
+        { resourceId: overrideId },
+        {
+          $set: {
+            menuItemId: body.menuItemId,
+            price: body.price,
+            currency: body.currency,
+            startsAt: parseDate(body.startsAt ?? undefined),
+            endsAt: parseDate(body.endsAt ?? undefined),
+            reason: body.reason ?? undefined,
+          },
+        },
+      );
+
+      const override = await collections.pricingOverrides.findOne({ resourceId: overrideId });
+      return { override: override ? formatPricingOverride(override) : null };
+    },
+  );
+
+  app.delete(
+    '/admin/pricing-overrides/:overrideId',
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const { overrideId } = request.params as { overrideId: string };
+      const collections = await request.getTenantCollections();
+      await collections.pricingOverrides.deleteOne({ resourceId: overrideId });
+      reply.code(204);
+    },
+  );
+
+  app.get(
+    '/admin/operating-hours',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+      const hours = await collections.operatingHours.find({}).toArray();
+      return { hours: hours.map(formatOperatingHour) };
+    },
+  );
+
+  app.post(
+    '/admin/operating-hours',
+    { preHandler: app.authenticate, schema: { body: operatingHourInputSchema } },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const body = request.body as {
+        id?: string | null;
+        dayOfWeek: number;
+        opensAt: string;
+        closesAt: string;
+        isClosed?: boolean | null;
+      };
+
+      const resourceId = body.id && body.id.length > 0 ? body.id : randomUUID();
+      await collections.operatingHours.updateOne(
+        { resourceId },
+        {
+          $setOnInsert: { resourceId, createdAt: new Date() },
+          $set: {
+            dayOfWeek: body.dayOfWeek,
+            opensAt: body.opensAt,
+            closesAt: body.closesAt,
+            isClosed: body.isClosed ?? undefined,
+          },
+        },
+        { upsert: true },
+      );
+
+      const hour = await collections.operatingHours.findOne({ resourceId });
+      reply.code(201);
+      return { operatingHour: hour ? formatOperatingHour(hour) : null };
+    },
+  );
+
+  app.put(
+    '/admin/operating-hours/:hourId',
+    { preHandler: app.authenticate, schema: { body: operatingHourInputSchema } },
+    async (request) => {
+      const { hourId } = request.params as { hourId: string };
+      const collections = await request.getTenantCollections();
+      const body = request.body as {
+        dayOfWeek: number;
+        opensAt: string;
+        closesAt: string;
+        isClosed?: boolean | null;
+      };
+
+      await collections.operatingHours.updateOne(
+        { resourceId: hourId },
+        {
+          $set: {
+            dayOfWeek: body.dayOfWeek,
+            opensAt: body.opensAt,
+            closesAt: body.closesAt,
+            isClosed: body.isClosed ?? undefined,
+          },
+        },
+      );
+
+      const hour = await collections.operatingHours.findOne({ resourceId: hourId });
+      return { operatingHour: hour ? formatOperatingHour(hour) : null };
+    },
+  );
+
+  app.delete(
+    '/admin/operating-hours/:hourId',
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const { hourId } = request.params as { hourId: string };
+      const collections = await request.getTenantCollections();
+      await collections.operatingHours.deleteOne({ resourceId: hourId });
+      reply.code(204);
+    },
+  );
+
+  app.get(
+    '/admin/devices',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+      const devices = await collections.devices.find({}).toArray();
+      return {
+        devices: devices.map((device) => ({
+          id: device.resourceId,
+          label: device.label,
+          type: device.type,
+          lastSeenAt: device.lastSeenAt?.toISOString() ?? null,
+        })),
+      };
+    },
+  );
+
+  app.post(
+    '/admin/devices',
+    { preHandler: app.authenticate, schema: { body: deviceInputSchema } },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const body = request.body as { id?: string | null; label: string; type: 'kiosk' | 'tablet' | 'mobile' };
+      const resourceId = body.id && body.id.length > 0 ? body.id : randomUUID();
+      await collections.devices.updateOne(
+        { resourceId },
+        {
+          $setOnInsert: { resourceId, createdAt: new Date() },
+          $set: { label: body.label, type: body.type },
+        },
+        { upsert: true },
+      );
+      const device = await collections.devices.findOne({ resourceId });
+      reply.code(201);
+      return {
+        device: device
+          ? {
+              id: device.resourceId,
+              label: device.label,
+              type: device.type,
+              lastSeenAt: device.lastSeenAt?.toISOString() ?? null,
+            }
+          : null,
+      };
+    },
+  );
+
+  app.put(
+    '/admin/devices/:deviceId',
+    { preHandler: app.authenticate, schema: { body: deviceInputSchema } },
+    async (request) => {
+      const { deviceId } = request.params as { deviceId: string };
+      const collections = await request.getTenantCollections();
+      const body = request.body as { label: string; type: 'kiosk' | 'tablet' | 'mobile' };
+      await collections.devices.updateOne(
+        { resourceId: deviceId },
+        { $set: { label: body.label, type: body.type } },
+      );
+      const device = await collections.devices.findOne({ resourceId: deviceId });
+      return {
+        device: device
+          ? {
+              id: device.resourceId,
+              label: device.label,
+              type: device.type,
+              lastSeenAt: device.lastSeenAt?.toISOString() ?? null,
+            }
+          : null,
+      };
+    },
+  );
+
+  app.post(
+    '/admin/devices/:deviceId/ping',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { deviceId } = request.params as { deviceId: string };
+      const collections = await request.getTenantCollections();
+      const now = new Date();
+      await collections.devices.updateOne(
+        { resourceId: deviceId },
+        { $set: { lastSeenAt: now } },
+      );
+      const device = await collections.devices.findOne({ resourceId: deviceId });
+      return {
+        device: device
+          ? {
+              id: device.resourceId,
+              label: device.label,
+              type: device.type,
+              lastSeenAt: device.lastSeenAt?.toISOString() ?? null,
+            }
+          : null,
+      };
+    },
+  );
+
+  app.get(
+    '/admin/orders',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const collections = await request.getTenantCollections();
+      const orders = await collections.orders
+        .find({}, { sort: { submittedAt: -1 }, limit: 100 })
+        .toArray();
+
+      return {
+        orders: orders.map((order) => ({
+          id: order.resourceId,
+          status: order.status,
+          total: order.total,
+          currency: order.currency,
+          submittedAt: order.submittedAt.toISOString(),
+          itemCount: order.items.reduce((sum, item) => sum + item.quantity, 0),
+          customer: order.customer ?? null,
+          notes: order.notes ?? null,
+        })),
+      };
+    },
+  );
+
+  app.post(
+    '/admin/reports/daily-sales/run',
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const { date } = (request.body ?? {}) as { date?: string };
+      const rangeStart = date ? new Date(date) : new Date();
+      rangeStart.setHours(0, 0, 0, 0);
+      const rangeEnd = new Date(rangeStart);
+      rangeEnd.setDate(rangeEnd.getDate() + 1);
+
+      const payload = await calculateDailySalesPayload(collections, rangeStart, rangeEnd);
+      const resourceId = randomUUID();
+      await collections.reports.insertOne({
+        resourceId,
+        reportType: 'daily-sales',
+        rangeStart,
+        rangeEnd,
+        generatedAt: new Date(),
+        payload,
+      });
+
+      const report = await collections.reports.findOne({ resourceId });
+      reply.code(201);
+      return { report: report ? formatReport(report) : null };
+    },
+  );
+
+  app.post(
+    '/admin/reports/popular-items/run',
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const collections = await request.getTenantCollections();
+      const { days } = (request.body ?? {}) as { days?: number };
+      const windowDays = Number.isFinite(days) && days && days > 0 ? days : 7;
+      const rangeEnd = new Date();
+      const rangeStart = new Date(rangeEnd);
+      rangeStart.setDate(rangeEnd.getDate() - windowDays);
+
+      const payload = await calculatePopularItemsPayload(collections, rangeStart, rangeEnd);
+      const resourceId = randomUUID();
+      await collections.reports.insertOne({
+        resourceId,
+        reportType: 'popular-items',
+        rangeStart,
+        rangeEnd,
+        generatedAt: new Date(),
+        payload,
+      });
+
+      const report = await collections.reports.findOne({ resourceId });
+      reply.code(201);
+      return { report: report ? formatReport(report) : null };
+    },
+  );
+
+  app.get(
+    '/admin/reports/:type',
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { type } = request.params as { type: 'daily-sales' | 'popular-items' };
+      const collections = await request.getTenantCollections();
+      const reports = await collections.reports
+        .find({ reportType: type }, { sort: { generatedAt: -1 }, limit: 20 })
+        .toArray();
+
+      return { reports: reports.map(formatReport) };
+    },
+  );
+}

--- a/services/api/src/services/password.ts
+++ b/services/api/src/services/password.ts
@@ -1,0 +1,33 @@
+import { pbkdf2Sync, randomBytes, timingSafeEqual } from 'crypto';
+
+const ITERATIONS = 120000;
+const KEY_LENGTH = 32;
+const DIGEST = 'sha256';
+
+export const hashPassword = (password: string): string => {
+  const salt = randomBytes(16).toString('hex');
+  const derivedKey = pbkdf2Sync(password, salt, ITERATIONS, KEY_LENGTH, DIGEST).toString('hex');
+  return `${ITERATIONS}:${salt}:${derivedKey}`;
+};
+
+export const verifyPassword = (password: string, storedHash: string): boolean => {
+  const [iterationStr, salt, storedKey] = storedHash.split(':');
+  if (!iterationStr || !salt || !storedKey) {
+    return false;
+  }
+
+  const iterations = Number.parseInt(iterationStr, 10);
+  if (!Number.isFinite(iterations) || iterations <= 0) {
+    return false;
+  }
+
+  const derived = pbkdf2Sync(password, salt, iterations, KEY_LENGTH, DIGEST).toString('hex');
+  const derivedBuffer = Buffer.from(derived, 'hex');
+  const storedBuffer = Buffer.from(storedKey, 'hex');
+
+  if (derivedBuffer.length !== storedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(derivedBuffer, storedBuffer);
+};

--- a/services/api/src/types/fastify.d.ts
+++ b/services/api/src/types/fastify.d.ts
@@ -1,13 +1,20 @@
 import 'fastify';
+import type { FastifyReply, FastifyRequest } from 'fastify';
 import { getTenantCollections, TenantCollections } from '../db/mongo';
+import type { AdminUserSession } from '../plugins/auth';
 
 declare module 'fastify' {
   interface FastifyRequest {
     tenantId: string;
     getTenantCollections: () => Promise<TenantCollections>;
+    adminUser?: AdminUserSession;
   }
 
   interface FastifyInstance {
     getTenantCollections: typeof getTenantCollections;
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    signAdminToken: (payload: { adminId: string; tenantId: string }) => string;
+    setAdminSessionCookie: (reply: FastifyReply, token: string) => void;
+    clearAdminSessionCookie: (reply: FastifyReply) => void;
   }
 }

--- a/src/components/admin/AdminGuard.tsx
+++ b/src/components/admin/AdminGuard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { AdminApiError, AdminSession, adminApi } from '@/lib/admin-api';
+
+type AdminGuardContextValue = {
+  session: AdminSession;
+  refresh: () => Promise<void>;
+};
+
+const AdminSessionContext = createContext<AdminGuardContextValue | null>(null);
+
+export const useAdminSession = (): AdminGuardContextValue | null => useContext(AdminSessionContext);
+
+export function AdminGuard({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<AdminSession | null | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let mounted = true;
+    const loadSession = async () => {
+      try {
+        const result = await adminApi.session();
+        if (!mounted) return;
+        setSession(result.admin);
+        setError(null);
+      } catch (err) {
+        if (!mounted) return;
+        if (err instanceof AdminApiError && err.status === 401) {
+          setSession(null);
+          if (pathname !== '/admin/login') {
+            router.replace('/admin/login');
+          }
+        } else {
+          setError('Unable to load administrator session');
+          setSession(null);
+        }
+      }
+    };
+
+    loadSession();
+
+    return () => {
+      mounted = false;
+    };
+  }, [pathname, router]);
+
+  const refresh = async () => {
+    try {
+      const result = await adminApi.session();
+      setSession(result.admin);
+    } catch (err) {
+      if (err instanceof AdminApiError && err.status === 401) {
+        setSession(null);
+        router.replace('/admin/login');
+      }
+      throw err;
+    }
+  };
+
+  const value = useMemo(() => {
+    if (!session) {
+      return null;
+    }
+    return { session, refresh };
+  }, [session]);
+
+  if (session === undefined) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <div className="rounded-md border border-slate-800 bg-slate-900 px-6 py-4 shadow-lg">
+          <p className="text-sm font-medium">Loading admin session…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    if (error) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+          <div className="rounded-md border border-red-900/40 bg-red-900/20 px-6 py-4 shadow-lg">
+            <p className="text-sm font-medium">{error}</p>
+          </div>
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  const contextValue: AdminGuardContextValue = value ?? { session, refresh };
+
+  return <AdminSessionContext.Provider value={contextValue}>{children}</AdminSessionContext.Provider>;
+}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { adminApi } from '@/lib/admin-api';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useAdminSession } from './AdminGuard';
+
+const links = [
+  { href: '/admin/menus', label: 'Menus' },
+  { href: '/admin/orders', label: 'Orders' },
+  { href: '/admin/devices', label: 'Devices' },
+  { href: '/admin/reports', label: 'Reports' },
+];
+
+export function AdminHeader() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const context = useAdminSession();
+  const session = context?.session;
+
+  const handleLogout = async () => {
+    await adminApi.logout();
+    router.replace('/admin/login');
+  };
+
+  return (
+    <header className="flex items-center justify-between border-b border-slate-800 bg-slate-950/80 px-6 py-4 backdrop-blur">
+      <div className="flex items-center gap-6">
+        <span className="text-lg font-semibold text-slate-100">Pizzakebab Admin</span>
+        <nav className="flex gap-1 text-sm text-slate-300">
+          {links.map((link) => {
+            const isActive = pathname.startsWith(link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={cn(
+                  buttonVariants({
+                    variant: isActive ? 'secondary' : 'ghost',
+                    size: 'sm',
+                  }),
+                  'px-3',
+                )}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+      <div className="flex items-center gap-3 text-sm text-slate-300">
+        <div className="text-right">
+          <p className="font-medium text-slate-100">{session?.name ?? session?.email}</p>
+          <p className="text-xs uppercase tracking-wide text-slate-400">
+            {session ? session.roles.join(', ') : '—'}
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={handleLogout}>
+          Sign out
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/admin/AdminLayoutClient.tsx
+++ b/src/components/admin/AdminLayoutClient.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { AdminGuard } from './AdminGuard';
+import { AdminHeader } from './AdminHeader';
+
+export function AdminLayoutClient({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isLogin = pathname === '/admin/login';
+
+  if (isLogin) {
+    return <div className="min-h-screen bg-slate-950 text-slate-100">{children}</div>;
+  }
+
+  return (
+    <AdminGuard>
+      <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+        <AdminHeader />
+        <main className="flex-1 overflow-y-auto px-6 py-8">
+          <div className="mx-auto w-full max-w-6xl space-y-8">{children}</div>
+        </main>
+      </div>
+    </AdminGuard>
+  );
+}

--- a/src/lib/admin-api.ts
+++ b/src/lib/admin-api.ts
@@ -1,0 +1,252 @@
+'use client';
+
+export type AdminSession = {
+  id: string;
+  email: string;
+  name?: string | null;
+  roles: string[];
+};
+
+export type AdminMenuItem = {
+  id: string;
+  name: string;
+  description?: string | null;
+  categoryKey?: string | null;
+  price: number;
+  currency: string;
+  isAvailable: boolean;
+  imageUrl?: string | null;
+  isPopular?: boolean;
+  isNew?: boolean;
+};
+
+export type AdminMenu = {
+  id: string;
+  name: string;
+  description?: string | null;
+  translationKey?: string | null;
+  isActive: boolean;
+  items: AdminMenuItem[];
+};
+
+export type AdminOrder = {
+  id: string;
+  status: string;
+  total: number;
+  currency: string;
+  submittedAt: string;
+  itemCount: number;
+  customer?: { name?: string; phone?: string; email?: string } | null;
+  notes?: string | null;
+};
+
+export type AdminDevice = {
+  id: string;
+  label: string;
+  type: 'kiosk' | 'tablet' | 'mobile';
+  lastSeenAt?: string | null;
+};
+
+export type AdminPricingOverride = {
+  id: string;
+  menuItemId: string;
+  price: number;
+  currency: string;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  reason?: string | null;
+};
+
+export type AdminOperatingHour = {
+  id: string;
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+  isClosed?: boolean;
+};
+
+export type AdminReport = {
+  id: string;
+  type: 'daily-sales' | 'popular-items';
+  rangeStart: string;
+  rangeEnd: string;
+  generatedAt: string;
+  payload: unknown;
+};
+
+export class AdminApiError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000';
+const TENANT_ID = process.env.NEXT_PUBLIC_TENANT_ID ?? 'pizzakebab';
+
+const buildHeaders = (extra?: HeadersInit): HeadersInit => ({
+  'Content-Type': 'application/json',
+  'x-tenant-id': TENANT_ID,
+  ...(extra ?? {}),
+});
+
+async function adminRequest<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    credentials: 'include',
+    ...init,
+    headers: buildHeaders(init.headers as HeadersInit | undefined),
+  });
+
+  if (!response.ok) {
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch (error) {
+      body = null;
+    }
+    throw new AdminApiError('Admin API request failed', response.status, body);
+  }
+
+  if (response.status === 204) {
+    return null as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export const adminApi = {
+  async login(email: string, password: string) {
+    return adminRequest<{ admin: AdminSession; token: string }>('/admin/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+  },
+  async logout() {
+    return adminRequest<{ success: boolean }>('/admin/auth/logout', { method: 'POST' });
+  },
+  async session() {
+    return adminRequest<{ admin: AdminSession }>('/admin/auth/session');
+  },
+  async menus() {
+    const result = await adminRequest<{ menus: AdminMenu[] }>('/admin/menus');
+    return result.menus;
+  },
+  async saveMenu(menu: Partial<AdminMenu>) {
+    if (menu.id) {
+      const result = await adminRequest<{ menu: AdminMenu | null }>(`/admin/menus/${menu.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(menu),
+      });
+      return result.menu;
+    }
+    const result = await adminRequest<{ menu: AdminMenu | null }>('/admin/menus', {
+      method: 'POST',
+      body: JSON.stringify(menu),
+    });
+    return result.menu;
+  },
+  async deleteMenu(menuId: string) {
+    await adminRequest(`/admin/menus/${menuId}`, { method: 'DELETE' });
+  },
+  async pricingOverrides() {
+    const result = await adminRequest<{ overrides: AdminPricingOverride[] }>('/admin/pricing-overrides');
+    return result.overrides;
+  },
+  async savePricingOverride(override: Partial<AdminPricingOverride>) {
+    if (override.id) {
+      const result = await adminRequest<{ override: AdminPricingOverride | null }>(
+        `/admin/pricing-overrides/${override.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify(override),
+        },
+      );
+      return result.override;
+    }
+    const result = await adminRequest<{ override: AdminPricingOverride | null }>('/admin/pricing-overrides', {
+      method: 'POST',
+      body: JSON.stringify(override),
+    });
+    return result.override;
+  },
+  async deletePricingOverride(id: string) {
+    await adminRequest(`/admin/pricing-overrides/${id}`, { method: 'DELETE' });
+  },
+  async operatingHours() {
+    const result = await adminRequest<{ hours: AdminOperatingHour[] }>('/admin/operating-hours');
+    return result.hours;
+  },
+  async saveOperatingHour(hour: Partial<AdminOperatingHour>) {
+    if (hour.id) {
+      const result = await adminRequest<{ operatingHour: AdminOperatingHour | null }>(
+        `/admin/operating-hours/${hour.id}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify(hour),
+        },
+      );
+      return result.operatingHour;
+    }
+    const result = await adminRequest<{ operatingHour: AdminOperatingHour | null }>('/admin/operating-hours', {
+      method: 'POST',
+      body: JSON.stringify(hour),
+    });
+    return result.operatingHour;
+  },
+  async deleteOperatingHour(id: string) {
+    await adminRequest(`/admin/operating-hours/${id}`, { method: 'DELETE' });
+  },
+  async devices() {
+    const result = await adminRequest<{ devices: AdminDevice[] }>('/admin/devices');
+    return result.devices;
+  },
+  async saveDevice(device: Partial<AdminDevice>) {
+    if (device.id) {
+      const result = await adminRequest<{ device: AdminDevice | null }>(`/admin/devices/${device.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(device),
+      });
+      return result.device;
+    }
+    const result = await adminRequest<{ device: AdminDevice | null }>('/admin/devices', {
+      method: 'POST',
+      body: JSON.stringify(device),
+    });
+    return result.device;
+  },
+  async pingDevice(deviceId: string) {
+    const result = await adminRequest<{ device: AdminDevice | null }>(`/admin/devices/${deviceId}/ping`, {
+      method: 'POST',
+    });
+    return result.device;
+  },
+  async deleteDevice(deviceId: string) {
+    await adminRequest(`/admin/devices/${deviceId}`, { method: 'DELETE' });
+  },
+  async orders() {
+    const result = await adminRequest<{ orders: AdminOrder[] }>('/admin/orders');
+    return result.orders;
+  },
+  async runDailySales(date?: string) {
+    const result = await adminRequest<{ report: AdminReport | null }>('/admin/reports/daily-sales/run', {
+      method: 'POST',
+      body: JSON.stringify({ date }),
+    });
+    return result.report;
+  },
+  async runPopularItems(days?: number) {
+    const result = await adminRequest<{ report: AdminReport | null }>('/admin/reports/popular-items/run', {
+      method: 'POST',
+      body: JSON.stringify({ days }),
+    });
+    return result.report;
+  },
+  async reports(type: 'daily-sales' | 'popular-items') {
+    const result = await adminRequest<{ reports: AdminReport[] }>(`/admin/reports/${type}`);
+    return result.reports;
+  },
+};


### PR DESCRIPTION
## Summary
- replace admin login, dashboard, menu, orders, devices, and reports screens with shared Card/Button/Input components for consistent styling
- introduce reusable Select and Textarea UI primitives to support admin forms and filters
- update the admin header navigation and sign-out control to use shared button variants

## Testing
- npm run lint *(fails: Next.js CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f89c96a288832f95dfea14951bc804