### PR TITLE
Add backend, frontend, and Docker unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --import tsx --test tests/menu-catalog.test.ts",
+    "test": "node --import tsx --test",
     "type-check": "tsc --noEmit",
     "analyze": "ANALYZE=true npm run build",
     "api:dev": "tsx services/api/src/index.ts",

--- a/tests/backend/health.test.ts
+++ b/tests/backend/health.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+import { buildServer } from '../../services/api/src/index';
+import * as mongoDb from '../../services/api/src/db/mongo';
+import * as seed from '../../services/api/src/seed';
+import * as printService from '../../services/api/src/services/print-service';
+
+type TenantCollectionsStub = {
+  tenants: {
+    findOne: () => Promise<unknown>;
+  };
+};
+
+const noopAsync = async () => {};
+const noop = () => {};
+
+const activeMocks: Array<{ mock: { restore: () => void } }> = [];
+
+const trackMock = (object: Record<string, unknown>, method: string, implementation: unknown) => {
+  const stub = mock.method(object, method as never, implementation as never);
+  activeMocks.push(stub as unknown as { mock: { restore: () => void } });
+  return stub;
+};
+
+afterEach(() => {
+  while (activeMocks.length > 0) {
+    activeMocks.pop()?.mock.restore();
+  }
+});
+
+const setupCommonMocks = (collections: TenantCollectionsStub) => {
+  trackMock(mongoDb as unknown as Record<string, unknown>, 'ensureIndexes', noopAsync);
+  trackMock(mongoDb as unknown as Record<string, unknown>, 'closeMongo', noopAsync);
+  trackMock(seed as unknown as Record<string, unknown>, 'seedTenantData', noopAsync);
+  trackMock(printService as unknown as Record<string, unknown>, 'startPrintServiceWorker', noop);
+  trackMock(mongoDb as unknown as Record<string, unknown>, 'getTenantCollections', async () => collections as any);
+};
+
+describe('API service health endpoints', () => {
+  it('responds with ok from /healthz without tenant headers', async () => {
+    setupCommonMocks({
+      tenants: {
+        findOne: async () => ({ resourceId: 'system' }),
+      },
+    });
+
+    const app = buildServer();
+    const response = await app.inject({
+      method: 'GET',
+      url: '/healthz',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { status: 'ok' });
+
+    await app.close();
+  });
+
+  it('reports ready when tenant lookup succeeds', async () => {
+    const findOneCalls: string[] = [];
+
+    setupCommonMocks({
+      tenants: {
+        findOne: async () => {
+          findOneCalls.push('called');
+          return { resourceId: 'demo' };
+        },
+      },
+    });
+
+    const app = buildServer();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/readyz',
+      headers: {
+        'x-tenant-id': 'demo',
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { status: 'ready' });
+    assert.equal(findOneCalls.length, 1);
+
+    await app.close();
+  });
+
+  it('reports error when tenant lookup throws', async () => {
+    setupCommonMocks({
+      tenants: {
+        findOne: async () => {
+          throw new Error('database offline');
+        },
+      },
+    });
+
+    const app = buildServer();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/readyz',
+      headers: {
+        'x-tenant-id': 'demo',
+      },
+    });
+
+    assert.equal(response.statusCode, 500);
+    assert.deepEqual(response.json(), { status: 'error' });
+
+    await app.close();
+  });
+});

--- a/tests/docker/docker-compose.test.ts
+++ b/tests/docker/docker-compose.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type ComposeConfig = Record<string, unknown>;
+
+type StackEntry = {
+  indent: number;
+  container: any;
+  key?: string;
+};
+
+const parseValue = (value: string) => {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    try {
+      return JSON.parse(trimmed.replace(/'/g, '"'));
+    } catch (error) {
+      return trimmed;
+    }
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (trimmed === 'true') {
+    return true;
+  }
+  if (trimmed === 'false') {
+    return false;
+  }
+  return trimmed;
+};
+
+const findNextMeaningfulLine = (lines: string[], startIndex: number): string | undefined => {
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue;
+    }
+    return trimmed;
+  }
+  return undefined;
+};
+
+const parseCompose = (content: string): ComposeConfig => {
+  const root: ComposeConfig = {};
+  const stack: StackEntry[] = [{ indent: -1, container: root }];
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const indent = line.length - trimmed.length;
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+
+    const parent = stack[stack.length - 1];
+
+    if (trimmed.startsWith('- ')) {
+      const value = parseValue(trimmed.slice(2));
+      if (Array.isArray(parent.container)) {
+        parent.container.push(value);
+      } else if (parent.key) {
+        const target = parent.container[parent.key];
+        if (!Array.isArray(target)) {
+          parent.container[parent.key] = [];
+        }
+        (parent.container[parent.key] as unknown[]).push(value);
+      }
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf(':');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const valuePart = trimmed.slice(separatorIndex + 1).trim();
+
+    if (valuePart.length === 0) {
+      const nextLine = findNextMeaningfulLine(lines, index) ?? '';
+      const isArray = nextLine.startsWith('- ');
+      const container = isArray ? [] : {};
+      (parent.container as Record<string, unknown>)[key] = container;
+      stack.push({ indent, container, key });
+    } else {
+      (parent.container as Record<string, unknown>)[key] = parseValue(valuePart);
+    }
+  }
+
+  return root;
+};
+
+describe('docker-compose configuration', () => {
+  const composePath = resolve(process.cwd(), 'docker-compose.yml');
+  const document = readFileSync(composePath, 'utf8');
+  const config = parseCompose(document) as any;
+
+  it('defines a MongoDB service with persistent storage', () => {
+    const mongo = config?.services?.mongo;
+    assert.ok(mongo, 'Mongo service should be defined');
+    assert.equal(mongo.image, 'mongo:6.0');
+    assert.deepEqual(mongo.ports, ['27017:27017']);
+    assert.equal(mongo.environment?.MONGO_INITDB_ROOT_USERNAME, 'root');
+    assert.equal(mongo.environment?.MONGO_INITDB_ROOT_PASSWORD, 'example');
+    assert.deepEqual(mongo.volumes, ['mongo-data:/data/db']);
+  });
+
+  it('connects the API service to Mongo with the expected defaults', () => {
+    const api = config?.services?.api;
+    assert.ok(api, 'API service should be defined');
+    assert.equal(api.depends_on?.[0], 'mongo');
+    assert.deepEqual(api.environment, {
+      PORT: 4000,
+      MONGO_URI: 'mongodb://root:example@mongo:27017/?authSource=admin',
+      MONGO_DB_NAME: 'pizzakebab',
+      TENANT_HOST_MAP: '{"localhost":"demo"}',
+      TENANT_BASE_DOMAIN: 'localhost',
+    });
+    assert.deepEqual(api.ports, ['4000:4000']);
+    assert.deepEqual(api.command, ['npm', 'run', 'api:start']);
+  });
+});

--- a/tests/frontend/cn.test.ts
+++ b/tests/frontend/cn.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { cn } from '../../src/lib/utils';
+
+describe('cn utility', () => {
+  it('merges tailwind variants by preference', () => {
+    const result = cn('p-2', 'p-4', { 'text-red-500': true, 'hidden': false });
+    assert.equal(result, 'p-4 text-red-500');
+  });
+
+  it('skips falsy values and trims whitespace', () => {
+    const result = cn('bg-white', null, undefined, false, '   text-sm   ');
+    assert.equal(result, 'bg-white text-sm');
+  });
+});


### PR DESCRIPTION
## Summary
- broaden the test script to run the whole Node test suite
- add Fastify health endpoint coverage with mocked infrastructure dependencies
- add lightweight unit checks for the cn utility and docker-compose configuration

## Testing
- npm test *(fails: missing local dependencies such as tsx in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8c865e99c832f999ffc6e9f701300