### PR TITLE
Refactor API cart and order routes to use domain adapters

### DIFF
--- a/services/api/src/adapters/http/carts.ts
+++ b/services/api/src/adapters/http/carts.ts
@@ -1,0 +1,46 @@
+import {
+  EnsureCartInput,
+  EnsureCartResult,
+  GetCartResult,
+  UpdateCartInput,
+  UpdateCartResult,
+  serializeCart,
+} from '../../domain';
+
+export interface CreateCartDto {
+  deviceId?: string;
+  sessionId?: string;
+  userId?: string;
+  promoCode?: string | null;
+}
+
+export interface UpdateCartDto {
+  items?: Array<{
+    menuItemId: string;
+    quantity: number;
+    notes?: string;
+  }>;
+  promoCode?: string | null;
+}
+
+type CartUseCaseResult = EnsureCartResult | GetCartResult | UpdateCartResult;
+
+export const mapCreateCartRequest = (body: CreateCartDto): EnsureCartInput => ({
+  identifiers: {
+    deviceId: body.deviceId,
+    sessionId: body.sessionId,
+    userId: body.userId,
+  },
+  promoCode: body.promoCode ?? null,
+});
+
+export const mapUpdateCartRequest = (cartId: string, body: UpdateCartDto): UpdateCartInput => ({
+  cartId,
+  items: body.items,
+  promoCode: body.promoCode ?? null,
+  shouldUpdatePromoCode: Object.prototype.hasOwnProperty.call(body, 'promoCode'),
+});
+
+export const mapCartResultToResponse = (result: CartUseCaseResult) => ({
+  cart: serializeCart(result.cart, result.summary),
+});

--- a/services/api/src/adapters/http/orders.ts
+++ b/services/api/src/adapters/http/orders.ts
@@ -1,0 +1,34 @@
+import { OrderReceipt, SubmitOrderInput } from '../../domain';
+
+export interface SubmitOrderDto {
+  cartId: string;
+  promoCode?: string | null;
+  notes?: string;
+  customer?: {
+    name?: string;
+    phone?: string;
+    email?: string;
+  };
+}
+
+export const mapSubmitOrderRequest = (body: SubmitOrderDto): SubmitOrderInput => ({
+  cartId: body.cartId,
+  promoCode: body.promoCode ?? null,
+  notes: body.notes,
+  customer: body.customer,
+});
+
+export const mapOrderReceiptToResponse = (receipt: OrderReceipt) => ({
+  order: {
+    id: receipt.order.id,
+    cartId: receipt.order.cartId,
+    status: receipt.order.status,
+    total: receipt.order.total,
+    currency: receipt.order.currency,
+    submittedAt: receipt.order.submittedAt.toISOString(),
+    promotion: receipt.order.promotion,
+    totals: receipt.order.totals,
+    customer: receipt.order.customer,
+    notes: receipt.order.notes,
+  },
+});

--- a/services/api/src/adapters/index.ts
+++ b/services/api/src/adapters/index.ts
@@ -3,3 +3,5 @@ export * from './cart-summary-builder';
 export * from './order-repository';
 export * from './kitchen-notifier';
 export * from './request-tenant-context-provider';
+export * from './http/carts';
+export * from './http/orders';

--- a/services/api/tests/integration/carts-routes.test.ts
+++ b/services/api/tests/integration/carts-routes.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { beforeEach, afterEach, describe, it, mock } from 'node:test';
+import Fastify, { FastifyInstance } from 'fastify';
+
+import cartsRoutes from '../../src/routes/carts';
+import type {
+  Cart,
+  CartSummary,
+  CartTotals,
+  EnsureCartResult,
+  GetCartResult,
+  TenantContextProvider,
+  UpdateCartResult,
+} from '../../src/domain';
+import * as domain from '../../src/domain';
+
+describe('carts routes', () => {
+  let app: FastifyInstance;
+  const tenantContextStub: TenantContextProvider = {
+    async getCartRepository() {
+      throw new Error('not implemented');
+    },
+    async getCartSummaryBuilder() {
+      throw new Error('not implemented');
+    },
+    async getOrderRepository() {
+      throw new Error('not implemented');
+    },
+    async getKitchenNotifier() {
+      throw new Error('not implemented');
+    },
+  };
+
+  const baseCart: Cart = {
+    id: 'cart-1',
+    deviceId: 'device-1',
+    sessionId: null,
+    userId: null,
+    status: 'open',
+    promoCode: null,
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    items: [],
+  };
+
+  const totals: CartTotals = {
+    subtotal: 0,
+    discount: 0,
+    deliveryFee: 0,
+    total: 0,
+    currency: 'USD',
+  };
+
+  const summary: CartSummary = {
+    items: [],
+    totals,
+    promotion: null,
+  };
+
+  beforeEach(async () => {
+    app = Fastify();
+    app.decorateRequest('tenantId', 'tenant-test');
+    app.decorateRequest('tenantContextProvider', null);
+    app.decorateRequest('getTenantContext', function () {
+      return tenantContextStub;
+    });
+    await app.register(cartsRoutes);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    await app.close();
+  });
+
+  it('delegates cart creation to the ensureCart use case', async () => {
+    const ensureCartMock = mock.method(domain, 'ensureCart', async () => ({
+      cart: baseCart,
+      summary,
+    }) satisfies EnsureCartResult);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/carts',
+      payload: {
+        deviceId: 'device-99',
+        promoCode: 'WELCOME',
+      },
+    });
+
+    assert.equal(ensureCartMock.mock.calls.length, 1);
+    const [deps, input] = ensureCartMock.mock.calls[0].arguments;
+    assert.equal(deps.tenantContext, tenantContextStub);
+    assert.equal(typeof deps.idGenerator, 'function');
+    assert.deepEqual(input, {
+      identifiers: {
+        deviceId: 'device-99',
+        sessionId: undefined,
+        userId: undefined,
+      },
+      promoCode: 'WELCOME',
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(await response.json(), {
+      cart: {
+        id: 'cart-1',
+        deviceId: 'device-1',
+        sessionId: null,
+        userId: null,
+        status: 'open',
+        promoCode: null,
+        createdAt: baseCart.createdAt.toISOString(),
+        updatedAt: baseCart.updatedAt.toISOString(),
+        items: [],
+        totals,
+        promotion: null,
+      },
+    });
+  });
+
+  it('delegates cart retrieval to the getActiveCart use case', async () => {
+    const getCartMock = mock.method(domain, 'getActiveCart', async () => ({
+      cart: baseCart,
+      summary,
+    }) satisfies GetCartResult);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/carts/cart-1',
+    });
+
+    assert.equal(getCartMock.mock.calls.length, 1);
+    const [deps, cartId] = getCartMock.mock.calls[0].arguments;
+    assert.equal(deps.tenantContext, tenantContextStub);
+    assert.equal(cartId, 'cart-1');
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(await response.json(), {
+      cart: {
+        id: 'cart-1',
+        deviceId: 'device-1',
+        sessionId: null,
+        userId: null,
+        status: 'open',
+        promoCode: null,
+        createdAt: baseCart.createdAt.toISOString(),
+        updatedAt: baseCart.updatedAt.toISOString(),
+        items: [],
+        totals,
+        promotion: null,
+      },
+    });
+  });
+
+  it('delegates cart updates to the updateCart use case', async () => {
+    const updateCartMock = mock.method(domain, 'updateCart', async () => ({
+      cart: baseCart,
+      summary,
+    }) satisfies UpdateCartResult);
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/carts/cart-1',
+      payload: {
+        items: [
+          {
+            menuItemId: 'item-1',
+            quantity: 2,
+          },
+        ],
+        promoCode: null,
+      },
+    });
+
+    assert.equal(updateCartMock.mock.calls.length, 1);
+    const [deps, input] = updateCartMock.mock.calls[0].arguments;
+    assert.equal(deps.tenantContext, tenantContextStub);
+    assert.deepEqual(input, {
+      cartId: 'cart-1',
+      items: [
+        {
+          menuItemId: 'item-1',
+          quantity: 2,
+        },
+      ],
+      promoCode: null,
+      shouldUpdatePromoCode: true,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(await response.json(), {
+      cart: {
+        id: 'cart-1',
+        deviceId: 'device-1',
+        sessionId: null,
+        userId: null,
+        status: 'open',
+        promoCode: null,
+        createdAt: baseCart.createdAt.toISOString(),
+        updatedAt: baseCart.updatedAt.toISOString(),
+        items: [],
+        totals,
+        promotion: null,
+      },
+    });
+  });
+});

--- a/services/api/tests/integration/orders-routes.test.ts
+++ b/services/api/tests/integration/orders-routes.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { beforeEach, afterEach, describe, it, mock } from 'node:test';
+import Fastify, { FastifyInstance } from 'fastify';
+
+import ordersRoutes from '../../src/routes/orders';
+import type { OrderReceipt, TenantContextProvider } from '../../src/domain';
+import * as domain from '../../src/domain';
+
+describe('orders routes', () => {
+  let app: FastifyInstance;
+  const tenantContextStub: TenantContextProvider = {
+    async getCartRepository() {
+      throw new Error('not implemented');
+    },
+    async getCartSummaryBuilder() {
+      throw new Error('not implemented');
+    },
+    async getOrderRepository() {
+      throw new Error('not implemented');
+    },
+    async getKitchenNotifier() {
+      throw new Error('not implemented');
+    },
+  };
+
+  beforeEach(async () => {
+    app = Fastify();
+    app.decorateRequest('tenantId', 'tenant-test');
+    app.decorateRequest('tenantContextProvider', null);
+    app.decorateRequest('getTenantContext', function () {
+      return tenantContextStub;
+    });
+    await app.register(ordersRoutes);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    mock.restoreAll();
+    await app.close();
+  });
+
+  it('invokes submitOrder use case through the HTTP handler', async () => {
+    const submittedAt = new Date('2024-01-01T00:00:00Z');
+    const receipt: OrderReceipt = {
+      order: {
+        id: 'order-1',
+        cartId: 'cart-1',
+        status: 'pending',
+        total: 42,
+        currency: 'USD',
+        submittedAt,
+        promotion: null,
+        totals: {
+          subtotal: 40,
+          discount: 0,
+          deliveryFee: 2,
+          total: 42,
+          currency: 'USD',
+        },
+        customer: { name: 'Ada Lovelace' },
+        notes: 'Leave at the door',
+      },
+      items: [],
+    };
+
+    const submitOrderMock = mock.method(domain, 'submitOrder', async () => receipt);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/orders',
+      payload: {
+        cartId: 'cart-1',
+        promoCode: 'SAVE10',
+        notes: 'Leave at the door',
+        customer: { name: 'Ada Lovelace' },
+      },
+    });
+
+    assert.equal(submitOrderMock.mock.calls.length, 1);
+    const [deps, input] = submitOrderMock.mock.calls[0].arguments;
+    assert.equal(deps.tenantContext, tenantContextStub);
+    assert.equal(typeof deps.idGenerator, 'function');
+    assert.equal(typeof deps.now, 'function');
+    assert.deepEqual(input, {
+      cartId: 'cart-1',
+      promoCode: 'SAVE10',
+      notes: 'Leave at the door',
+      customer: { name: 'Ada Lovelace' },
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(await response.json(), {
+      order: {
+        id: 'order-1',
+        cartId: 'cart-1',
+        status: 'pending',
+        total: 42,
+        currency: 'USD',
+        submittedAt: submittedAt.toISOString(),
+        promotion: null,
+        totals: {
+          subtotal: 40,
+          discount: 0,
+          deliveryFee: 2,
+          total: 42,
+          currency: 'USD',
+        },
+        customer: { name: 'Ada Lovelace' },
+        notes: 'Leave at the door',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated HTTP mappers that translate cart and order request/response DTOs to domain types
- refactor the carts and orders routes to delegate to the domain use cases through the new mappers
- add fastify integration tests that assert the handlers invoke the expected use cases

## Testing
- npm test *(fails: node cannot resolve the tsx loader module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fde4fae424832f989e8622b4423b07