### PR TITLE
Refactor cart provider to use domain services

### DIFF
--- a/src/adapters/http/cart-service.ts
+++ b/src/adapters/http/cart-service.ts
@@ -1,0 +1,50 @@
+import { apiFetch } from "@/lib/api-client"
+import type {
+  Cart,
+  CartService,
+  CreateCartCommand,
+  Order,
+  SubmitOrderCommand,
+  UpdateCartCommand,
+} from "@/domain/cart"
+
+interface CartResponse {
+  cart: Cart
+}
+
+interface OrderResponse {
+  order: Order
+}
+
+export class HttpCartService implements CartService {
+  async createOrGetCart(payload: CreateCartCommand): Promise<Cart> {
+    const response = await apiFetch<CartResponse>("/carts", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+    return response.cart
+  }
+
+  async getCart(cartId: string): Promise<Cart> {
+    const response = await apiFetch<CartResponse>(`/carts/${cartId}`)
+    return response.cart
+  }
+
+  async updateCart(cartId: string, payload: UpdateCartCommand): Promise<Cart> {
+    const response = await apiFetch<CartResponse>(`/carts/${cartId}`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    })
+    return response.cart
+  }
+
+  async submitOrder(payload: SubmitOrderCommand): Promise<Order> {
+    const response = await apiFetch<OrderResponse>("/orders", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    })
+    return response.order
+  }
+}
+
+export const httpCartService = new HttpCartService()

--- a/src/adapters/http/index.ts
+++ b/src/adapters/http/index.ts
@@ -1,0 +1,1 @@
+export * from "./cart-service"

--- a/src/domain/cart/index.ts
+++ b/src/domain/cart/index.ts
@@ -1,0 +1,2 @@
+export * from "./types"
+export type { CartService } from "./service"

--- a/src/domain/cart/service.ts
+++ b/src/domain/cart/service.ts
@@ -1,0 +1,14 @@
+import type {
+  Cart,
+  CreateCartCommand,
+  SubmitOrderCommand,
+  UpdateCartCommand,
+  Order,
+} from "./types"
+
+export interface CartService {
+  createOrGetCart(payload: CreateCartCommand): Promise<Cart>
+  getCart(cartId: string): Promise<Cart>
+  updateCart(cartId: string, payload: UpdateCartCommand): Promise<Cart>
+  submitOrder(payload: SubmitOrderCommand): Promise<Order>
+}

--- a/src/domain/cart/types.ts
+++ b/src/domain/cart/types.ts
@@ -1,4 +1,3 @@
-import { apiFetch } from "@/lib/api-client"
 import type { TranslationKey } from "@/lib/translations"
 
 export interface CartMenuItem {
@@ -41,12 +40,14 @@ export interface AppliedPromotion {
   description?: string
 }
 
-export interface CartApi {
+export type CartStatus = "open" | "checked_out"
+
+export interface Cart {
   id: string
   deviceId: string
   sessionId?: string | null
   userId?: string | null
-  status: "open" | "checked_out"
+  status: CartStatus
   promoCode?: string | null
   createdAt: string
   updatedAt: string
@@ -55,38 +56,30 @@ export interface CartApi {
   promotion?: AppliedPromotion | null
 }
 
-export interface CartResponse {
-  cart: CartApi
+export interface Order {
+  id: string
+  cartId: string
+  status: string
+  total: number
+  currency: string
+  submittedAt: string
+  promotion?: AppliedPromotion | null
+  totals: CartTotals
 }
 
-export interface CreateCartPayload {
+export interface CreateCartCommand {
   deviceId?: string
   sessionId?: string
   userId?: string
   promoCode?: string
 }
 
-export interface UpdateCartPayload {
+export interface UpdateCartCommand {
   items?: Array<{ menuItemId: string; quantity: number; notes?: string }>
   promoCode?: string | null
 }
 
-export const createOrGetCart = (payload: CreateCartPayload): Promise<CartResponse> =>
-  apiFetch<CartResponse>("/carts", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  })
-
-export const getCart = (cartId: string): Promise<CartResponse> =>
-  apiFetch<CartResponse>(`/carts/${cartId}`)
-
-export const updateCart = (cartId: string, payload: UpdateCartPayload): Promise<CartResponse> =>
-  apiFetch<CartResponse>(`/carts/${cartId}`, {
-    method: "PUT",
-    body: JSON.stringify(payload),
-  })
-
-export interface SubmitOrderPayload {
+export interface SubmitOrderCommand {
   cartId: string
   promoCode?: string | null
   notes?: string
@@ -96,23 +89,3 @@ export interface SubmitOrderPayload {
     email?: string
   }
 }
-
-export interface OrderResponse {
-  order: {
-    id: string
-    cartId: string
-    status: string
-    total: number
-    currency: string
-    submittedAt: string
-    promotion?: AppliedPromotion | null
-    totals: CartTotals
-  }
-}
-
-export const submitOrder = (payload: SubmitOrderPayload): Promise<OrderResponse> =>
-  apiFetch<OrderResponse>("/orders", {
-    method: "POST",
-    body: JSON.stringify(payload),
-  })
-

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,1 @@
+export * from "./cart"

--- a/tests/cart-provider.test.tsx
+++ b/tests/cart-provider.test.tsx
@@ -1,0 +1,452 @@
+import assert from "node:assert/strict"
+import { afterEach, before, describe, it } from "node:test"
+import React, { useEffect } from "react"
+import { act } from "react-dom/test-utils"
+import { createRoot, type Root } from "react-dom/client"
+
+import { CartProvider, useCart } from "@/contexts/cart-context"
+import { LanguageProvider } from "@/contexts/language-context"
+import type {
+  Cart,
+  CartLineItem,
+  CartService,
+  CreateCartCommand,
+  Order,
+  SubmitOrderCommand,
+  UpdateCartCommand,
+} from "@/domain/cart"
+
+class LocalStorageMock {
+  private store = new Map<string, string>()
+
+  get length() {
+    return this.store.size
+  }
+
+  clear() {
+    this.store.clear()
+  }
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+}
+
+class MockNode {
+  public parentNode: MockNode | null = null
+  public childNodes: MockNode[] = []
+  public ownerDocument: MockDocument
+  public textContent: string | null = null
+
+  constructor(public readonly nodeType: number, public readonly nodeName: string, ownerDocument: MockDocument) {
+    this.ownerDocument = ownerDocument
+  }
+
+  appendChild<T extends MockNode>(node: T): T {
+    this.childNodes.push(node)
+    node.parentNode = this
+    return node
+  }
+
+  removeChild<T extends MockNode>(node: T): T {
+    const index = this.childNodes.indexOf(node)
+    if (index === -1) {
+      throw new Error("Node to remove was not found in children")
+    }
+    this.childNodes.splice(index, 1)
+    node.parentNode = null
+    return node
+  }
+
+  insertBefore<T extends MockNode>(node: T, referenceNode: MockNode | null): T {
+    if (!referenceNode) {
+      return this.appendChild(node)
+    }
+    const index = this.childNodes.indexOf(referenceNode)
+    if (index === -1) {
+      return this.appendChild(node)
+    }
+    this.childNodes.splice(index, 0, node)
+    node.parentNode = this
+    return node
+  }
+
+  contains(node: MockNode | null): boolean {
+    if (!node) {
+      return false
+    }
+    if (node === this) {
+      return true
+    }
+    return this.childNodes.some((child) => child.contains(node))
+  }
+}
+
+class MockElement extends MockNode {
+  public readonly attributes = new Map<string, string>()
+  public readonly style: Record<string, string> = {}
+  public readonly dataset: Record<string, string> = {}
+  public tagName: string
+
+  constructor(tagName: string, ownerDocument: MockDocument) {
+    super(1, tagName.toUpperCase(), ownerDocument)
+    this.tagName = tagName.toUpperCase()
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, String(value))
+  }
+
+  removeAttribute(name: string) {
+    this.attributes.delete(name)
+  }
+
+  get firstChild() {
+    return this.childNodes[0] ?? null
+  }
+
+  get lastChild() {
+    return this.childNodes[this.childNodes.length - 1] ?? null
+  }
+
+  get innerHTML() {
+    return this.childNodes.map((child) => child.textContent ?? "").join("")
+  }
+
+  set innerHTML(value: string) {
+    this.childNodes = []
+    if (value) {
+      const textNode = this.ownerDocument.createTextNode(value)
+      this.appendChild(textNode)
+    }
+  }
+}
+
+class MockText extends MockNode {
+  constructor(text: string, ownerDocument: MockDocument) {
+    super(3, "#text", ownerDocument)
+    this.textContent = text
+  }
+}
+
+class MockComment extends MockNode {
+  public nodeValue: string
+
+  constructor(text: string, ownerDocument: MockDocument) {
+    super(8, "#comment", ownerDocument)
+    this.textContent = text
+    this.nodeValue = text
+  }
+}
+
+class MockDocumentFragment extends MockNode {
+  constructor(ownerDocument: MockDocument) {
+    super(11, "#document-fragment", ownerDocument)
+  }
+}
+
+class MockDocument {
+  public readonly body: MockElement
+  public readonly documentElement: MockElement
+  public defaultView: Window & typeof globalThis
+
+  constructor() {
+    this.documentElement = new MockElement("html", this)
+    this.body = new MockElement("body", this)
+    this.documentElement.appendChild(this.body)
+    this.defaultView = globalThis as Window & typeof globalThis
+  }
+
+  createElement(tagName: string) {
+    return new MockElement(tagName, this)
+  }
+
+  createTextNode(text: string) {
+    return new MockText(text, this)
+  }
+
+  createComment(text: string) {
+    return new MockComment(text, this)
+  }
+
+  createDocumentFragment() {
+    return new MockDocumentFragment(this)
+  }
+}
+
+type CartValue = ReturnType<typeof useCart>
+
+function TestConsumer({ onValue }: { onValue: (value: CartValue) => void }) {
+  const value = useCart()
+
+  useEffect(() => {
+    onValue(value)
+  }, [value, onValue])
+
+  return null
+}
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value))
+
+interface UpdateCall {
+  cartId: string
+  payload: UpdateCartCommand
+}
+
+class MockCartService implements CartService {
+  public readonly calls = {
+    create: [] as CreateCartCommand[],
+    get: [] as string[],
+    update: [] as UpdateCall[],
+    submit: [] as SubmitOrderCommand[],
+  }
+
+  private currentCart: Cart
+
+  constructor(initialCart: Cart) {
+    this.currentCart = clone(initialCart)
+  }
+
+  async createOrGetCart(payload: CreateCartCommand): Promise<Cart> {
+    this.calls.create.push(payload)
+    this.currentCart.sessionId = payload.sessionId ?? this.currentCart.sessionId ?? null
+    return this.cloneCart()
+  }
+
+  async getCart(cartId: string): Promise<Cart> {
+    this.calls.get.push(cartId)
+    return this.cloneCart()
+  }
+
+  async updateCart(cartId: string, payload: UpdateCartCommand): Promise<Cart> {
+    this.calls.update.push({ cartId, payload })
+    if (payload.items) {
+      this.currentCart.items = payload.items.map((item) => this.createLineItem(item))
+    }
+    if (payload.promoCode !== undefined) {
+      this.currentCart.promoCode = payload.promoCode
+    }
+    this.recalculateTotals()
+    this.currentCart.updatedAt = new Date().toISOString()
+    return this.cloneCart()
+  }
+
+  async submitOrder(payload: SubmitOrderCommand): Promise<Order> {
+    this.calls.submit.push(payload)
+    return {
+      id: "order-1",
+      cartId: payload.cartId,
+      status: "submitted",
+      total: this.currentCart.totals.total,
+      currency: this.currentCart.totals.currency,
+      submittedAt: new Date().toISOString(),
+      promotion: this.currentCart.promotion ?? null,
+      totals: clone(this.currentCart.totals),
+    }
+  }
+
+  private createLineItem(item: { menuItemId: string; quantity: number; notes?: string }): CartLineItem {
+    const basePrice = 12
+    return {
+      menuItemId: item.menuItemId,
+      quantity: item.quantity,
+      notes: item.notes,
+      menuItem: {
+        id: item.menuItemId,
+        menuId: "menu-1",
+        name: `Item ${item.menuItemId}`,
+        price: basePrice,
+        currency: this.currentCart.totals.currency,
+        isAvailable: true,
+      },
+    }
+  }
+
+  private recalculateTotals() {
+    const subtotal = this.currentCart.items.reduce((total, line) => {
+      const unitPrice = line.menuItem?.price ?? 0
+      return total + unitPrice * line.quantity
+    }, 0)
+    const deliveryFee = this.currentCart.totals.deliveryFee
+    const discount = this.currentCart.promoCode ? 2 : 0
+    const total = Math.max(subtotal - discount + deliveryFee, 0)
+
+    this.currentCart.totals = {
+      ...this.currentCart.totals,
+      subtotal,
+      discount,
+      total,
+    }
+  }
+
+  private cloneCart(): Cart {
+    return clone(this.currentCart)
+  }
+}
+
+function createCart(overrides: Partial<Cart> = {}): Cart {
+  const now = new Date().toISOString()
+  return {
+    id: "cart-1",
+    deviceId: "device-1",
+    sessionId: "session-1",
+    userId: null,
+    status: "open",
+    promoCode: null,
+    createdAt: now,
+    updatedAt: now,
+    items: [
+      {
+        menuItemId: "42",
+        quantity: 1,
+        menuItem: {
+          id: "42",
+          menuId: "menu-1",
+          name: "Four Cheese Pizza",
+          price: 18,
+          currency: "EUR",
+          isAvailable: true,
+        },
+      },
+    ],
+    totals: {
+      subtotal: 18,
+      deliveryFee: 5,
+      discount: 0,
+      total: 23,
+      currency: "EUR",
+    },
+    promotion: null,
+    ...overrides,
+  }
+}
+
+function setupDomEnvironment() {
+  if (typeof globalThis.document !== "undefined") {
+    return
+  }
+  const document = new MockDocument()
+  const window = globalThis as Window & typeof globalThis
+  const storage = new LocalStorageMock()
+  document.defaultView = window
+  window.document = document as unknown as Document
+  window.localStorage = storage as unknown as Storage
+  window.navigator = { userAgent: "node" } as Navigator
+  window.window = window
+  globalThis.window = window
+  globalThis.document = window.document
+  globalThis.localStorage = storage as unknown as Storage
+  globalThis.navigator = window.navigator
+  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+}
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("CartProvider with mock CartService", () => {
+  let root: Root | null = null
+  let container: MockElement | null = null
+
+  before(() => {
+    setupDomEnvironment()
+  })
+
+  afterEach(() => {
+    if (root) {
+      root.unmount()
+      root = null
+    }
+    container = null
+    if (globalThis.localStorage) {
+      globalThis.localStorage.clear()
+    }
+  })
+
+  it("initializes cart state via injected service", async () => {
+    const service = new MockCartService(createCart())
+    container = (document as unknown as MockDocument).createElement("div")
+    root = createRoot(container as unknown as Element)
+
+    let latestValue: CartValue | undefined
+    const handleValue = (value: CartValue) => {
+      latestValue = value
+    }
+
+    act(() => {
+      root.render(
+        <LanguageProvider>
+          <CartProvider service={service}>
+            <TestConsumer onValue={handleValue} />
+          </CartProvider>
+        </LanguageProvider>,
+      )
+    })
+
+    await flushPromises()
+
+    assert.equal(service.calls.create.length, 1)
+    assert.ok(latestValue, "Cart context value should be defined after initialization")
+    assert.equal(latestValue?.itemCount, 1)
+    assert.equal(latestValue?.items[0]?.name, "Four Cheese Pizza")
+    assert.equal(latestValue?.subtotal, 18)
+    assert.equal(latestValue?.deliveryFee, 5)
+  })
+
+  it("updates cart items without touching real API", async () => {
+    const service = new MockCartService(createCart({ items: [] }))
+    container = (document as unknown as MockDocument).createElement("div")
+    root = createRoot(container as unknown as Element)
+
+    let latestValue: CartValue | undefined
+    const handleValue = (value: CartValue) => {
+      latestValue = value
+    }
+
+    act(() => {
+      root.render(
+        <LanguageProvider>
+          <CartProvider service={service}>
+            <TestConsumer onValue={handleValue} />
+          </CartProvider>
+        </LanguageProvider>,
+      )
+    })
+
+    await flushPromises()
+    assert.ok(latestValue)
+
+    await act(async () => {
+      await latestValue?.addItem({ id: 101, name: "Garlic Bread", price: 6 }, 2)
+      await flushPromises()
+    })
+
+    assert.equal(service.calls.update.length, 1)
+    const updatePayload = service.calls.update[0]?.payload
+    assert.ok(updatePayload?.items)
+    assert.equal(updatePayload?.items?.[0]?.menuItemId, "101")
+    assert.equal(updatePayload?.items?.[0]?.quantity, 2)
+
+    assert.equal(latestValue?.itemCount, 2)
+    assert(
+      latestValue?.items.some((item) => item.id === 101 && item.quantity === 2),
+      "Cart items should include the newly added product",
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add cart domain models and a CartService contract under `src/domain`
- provide an HTTP CartService adapter and update the React cart provider to depend on the interface
- add unit tests that exercise the cart provider with a mock service without calling the real API

## Testing
- npm test *(fails: missing `tsx` dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fde7593bd0832fa6b8949cf1a9cbdc